### PR TITLE
Fix -> iOS crash when invalid audio url

### DIFF
--- a/ios/Classes/SwiftAlarmPlugin.swift
+++ b/ios/Classes/SwiftAlarmPlugin.swift
@@ -85,9 +85,11 @@ public class SwiftAlarmPlugin: NSObject, FlutterPlugin {
         self.audioPlayers[id] = audioPlayer
       } catch {
         result(FlutterError.init(code: "NATIVE_ERR", message: "[Alarm] Error loading AVAudioPlayer with given asset path or url", details: nil))
+        return
       }
     } else {
       result(FlutterError.init(code: "NATIVE_ERR", message: "[Alarm] Error with audio file: path is \(assetAudio)", details: nil))
+      return
     }
 
     let currentTime = self.audioPlayers[id]!.deviceCurrentTime


### PR DESCRIPTION
The purpose of this pull request is to fix ios app crash when you set invalid audio url.

Description: If you set invalid assetAudio link for <code>setAlarm</code> method it handles in try - catch block and calls <code>result(FlutterError.init(...))</code>. But it doesn't stop execution of <code>setAlarm</code>. And at the next unwraping <code>let currentTime = self.audioPlayers[id]!.deviceCurrentTime</code> app crashes.