### PR TITLE
Fix alarm sound from background mode in ios

### DIFF
--- a/ios/Classes/SwiftAlarmPlugin.swift
+++ b/ios/Classes/SwiftAlarmPlugin.swift
@@ -108,9 +108,10 @@ public class SwiftAlarmPlugin: NSObject, FlutterPlugin {
     if fadeDuration > 0.0 {
       self.audioPlayers[id]!.volume = 0.1
     }
-
+      
+    self.audioPlayers[id]!.play(atTime: time)
+    
     self.tasksQueue[id] = DispatchWorkItem(block: {
-      self.audioPlayers[id]!.play()
       self.handleAlarmAfterDelay(
         id: id,
         triggerTime: dateTime,


### PR DESCRIPTION
The purpose of this pull request is to fix sound on ios.

If you set an alarm and go to background mode for more than 30 seconds, the notification will appear without sound. <code>DispatchQueue.main.asyncAfter</code> will not trigger.

<code>self.audioPlayers[id]!.play(atTime: time)</code>  fixes the sound and wakes up <code>DispatchQueue.main.asyncAfter</code> with some delay. 

I tested it with different amounts of time in background mode.

For example, if you are in background mode for about 1 minute, vibration will be triggered 4-5 seconds after the sound.
If you stay in background mode for 15 minutes - the delay will be about 1 minute.