### PR TITLE
Enable custom time zone selection for notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ assetAudio |   `String`     | The path to you audio asset you want to use as rin
 loopAudio |   `bool`     | If true, audio will repeat indefinitely until alarm is stopped.
 vibrate |   `bool`     | If true, device will vibrate indefinitely until alarm is stopped. If [loopAudio] is set to false, vibrations will stop when audio ends.
 fadeDuration |   `double`     | Duration, in seconds, over which to fade the alarm volume. Set to 0 by default, which means no fade.
+notificationTimeZonId |   `String`     | The time zone id of the notification triggered when alarm rings if app is on background. If not set, the time zone ID of UTC will be used.
 notificationTitle |   `String`     | The title of the notification triggered when alarm rings if app is on background.
 notificationBody | `String` | The body of the notification.
 enableNotificationOnKill |   `bool`     | Whether to show a notification when application is killed to warn the user that the alarm he set may not ring. Enabled by default.

--- a/lib/alarm.dart
+++ b/lib/alarm.dart
@@ -78,13 +78,13 @@ class Alarm {
 
     await AlarmStorage.saveAlarm(alarmSettings);
 
-    if (alarmSettings.notificationTitle != null &&
-        alarmSettings.notificationBody != null) {
+    if (alarmSettings.notificationTitle != null && alarmSettings.notificationBody != null) {
       if (alarmSettings.notificationTitle!.isNotEmpty &&
           alarmSettings.notificationBody!.isNotEmpty) {
         await AlarmNotification.instance.scheduleAlarmNotif(
           id: alarmSettings.id,
           dateTime: alarmSettings.dateTime,
+          locationName: alarmSettings.notificationTimeZoneId,
           title: alarmSettings.notificationTitle!,
           body: alarmSettings.notificationBody!,
         );

--- a/lib/model/alarm_settings.dart
+++ b/lib/model/alarm_settings.dart
@@ -11,6 +11,7 @@ class AlarmSettings {
     this.loopAudio = true,
     this.vibrate = true,
     this.fadeDuration = 0.0,
+    this.notificationTimeZoneId = 'UTC',
     this.notificationTitle,
     this.notificationBody,
     this.enableNotificationOnKill = true,
@@ -42,6 +43,10 @@ class AlarmSettings {
   /// Set to 0.0 by default, which means no fade.
   final double fadeDuration;
 
+  /// Time zone identifier to be used for the notification.
+  /// The default value is `UTC`.
+  final String notificationTimeZoneId;
+
   /// Title of the notification to be shown when alarm is triggered.
   /// Must not be null nor empty to show a notification.
   final String? notificationTitle;
@@ -65,6 +70,7 @@ class AlarmSettings {
     bool? loopAudio,
     bool? vibrate,
     double? fadeDuration,
+    String? notificationTimeZoneId,
     String? notificationTitle,
     String? notificationBody,
     bool? enableNotificationOnKill,
@@ -77,12 +83,11 @@ class AlarmSettings {
       loopAudio: loopAudio ?? this.loopAudio,
       vibrate: vibrate ?? this.vibrate,
       fadeDuration: fadeDuration ?? this.fadeDuration,
+      notificationTimeZoneId: notificationTimeZoneId ?? this.notificationTimeZoneId,
       notificationTitle: notificationTitle ?? this.notificationTitle,
       notificationBody: notificationBody ?? this.notificationBody,
-      enableNotificationOnKill:
-          enableNotificationOnKill ?? this.enableNotificationOnKill,
-      stopOnNotificationOpen:
-          stopOnNotificationOpen ?? this.stopOnNotificationOpen,
+      enableNotificationOnKill: enableNotificationOnKill ?? this.enableNotificationOnKill,
+      stopOnNotificationOpen: stopOnNotificationOpen ?? this.stopOnNotificationOpen,
     );
   }
 
@@ -94,6 +99,7 @@ class AlarmSettings {
         loopAudio: json['loopAudio'] as bool,
         vibrate: json['vibrate'] as bool,
         fadeDuration: json['fadeDuration'] as double,
+        notificationTimeZoneId: json['notificationTimeZoneId'] as String,
         notificationTitle: json['notificationTitle'] as String?,
         notificationBody: json['notificationBody'] as String?,
         enableNotificationOnKill: json['enableNotificationOnKill'] as bool,
@@ -108,6 +114,7 @@ class AlarmSettings {
         'loopAudio': loopAudio,
         'vibrate': vibrate,
         'fadeDuration': fadeDuration,
+        'notificationTimeZoneId': notificationTimeZoneId,
         'notificationTitle': notificationTitle,
         'notificationBody': notificationBody,
         'enableNotificationOnKill': enableNotificationOnKill,

--- a/lib/service/notification.dart
+++ b/lib/service/notification.dart
@@ -12,8 +12,7 @@ class AlarmNotification {
 
   static final instance = AlarmNotification._();
 
-  final FlutterLocalNotificationsPlugin localNotif =
-      FlutterLocalNotificationsPlugin();
+  final FlutterLocalNotificationsPlugin localNotif = FlutterLocalNotificationsPlugin();
 
   /// Adds configuration for local notifications and initialize service.
   Future<void> init() async {
@@ -71,13 +70,11 @@ class AlarmNotification {
 
     if (defaultTargetPlatform == TargetPlatform.android) {
       result = await localNotif
-          .resolvePlatformSpecificImplementation<
-              AndroidFlutterLocalNotificationsPlugin>()
+          .resolvePlatformSpecificImplementation<AndroidFlutterLocalNotificationsPlugin>()
           ?.requestPermission();
     } else {
       result = await localNotif
-          .resolvePlatformSpecificImplementation<
-              IOSFlutterLocalNotificationsPlugin>()
+          .resolvePlatformSpecificImplementation<IOSFlutterLocalNotificationsPlugin>()
           ?.requestPermissions(
             alert: true,
             badge: true,
@@ -87,7 +84,7 @@ class AlarmNotification {
     return result ?? false;
   }
 
-  tz.TZDateTime nextInstanceOfTime(Time time) {
+  tz.TZDateTime nextInstanceOfTime(Time time, tz.Location location) {
     final DateTime now = DateTime.now();
 
     DateTime scheduledDate = DateTime(
@@ -103,13 +100,14 @@ class AlarmNotification {
       scheduledDate = scheduledDate.add(const Duration(days: 1));
     }
 
-    return tz.TZDateTime.from(scheduledDate, tz.local);
+    return tz.TZDateTime.from(scheduledDate, location);
   }
 
   /// Schedules notification at the given [dateTime].
   Future<void> scheduleAlarmNotif({
     required int id,
     required DateTime dateTime,
+    String locationName = 'UTC',
     required String title,
     required String body,
   }) async {
@@ -140,6 +138,7 @@ class AlarmNotification {
         dateTime.minute,
         dateTime.second,
       ),
+      tz.getLocation(locationName),
     );
 
     final hasPermission = await requestPermission();
@@ -153,11 +152,10 @@ class AlarmNotification {
         id,
         title,
         body,
-        tz.TZDateTime.from(zdt.toUtc(), tz.UTC),
+        zdt,
         platformChannelSpecifics,
         androidAllowWhileIdle: true,
-        uiLocalNotificationDateInterpretation:
-            UILocalNotificationDateInterpretation.absoluteTime,
+        uiLocalNotificationDateInterpretation: UILocalNotificationDateInterpretation.absoluteTime,
       );
       alarmPrint('Notification with id $id scheduled successfuly at $zdt');
     } catch (e) {

--- a/lib/service/notification.dart
+++ b/lib/service/notification.dart
@@ -107,7 +107,7 @@ class AlarmNotification {
   Future<void> scheduleAlarmNotif({
     required int id,
     required DateTime dateTime,
-    String locationName = 'UTC',
+    required String locationName,
     required String title,
     required String body,
   }) async {


### PR DESCRIPTION
Allow the TimeZoneId to be freely set, enabling the notification time zone to be customized. Currently, the time zone is fixed to UTC, which makes it inconvenient to use, so I made this modification."