### PR TITLE
Fixed pickTime

### DIFF
--- a/example/lib/screens/edit_alarm.dart
+++ b/example/lib/screens/edit_alarm.dart
@@ -47,14 +47,15 @@ class _ExampleAlarmEditScreenState extends State<ExampleAlarmEditScreen> {
     final today = DateTime(now.year, now.month, now.day);
     final difference = selectedDateTime.difference(today).inDays;
 
-    if (difference == 0) {
-      return 'Today';
-    } else if (difference == 1) {
-      return 'Tomorrow';
-    } else if (difference == 2) {
-      return 'After tomorrow';
-    } else {
-      return 'In $difference days';
+    switch (difference) {
+      case 0:
+        return 'Today';
+      case 1:
+        return 'Tomorrow';
+      case 2:
+        return 'After tomorrow';
+      default:
+        return 'In $difference days';
     }
   }
 
@@ -66,11 +67,15 @@ class _ExampleAlarmEditScreenState extends State<ExampleAlarmEditScreen> {
 
     if (res != null) {
       setState(() {
-        selectedDateTime = selectedDateTime.copyWith(
+        final DateTime now = DateTime.now();
+        selectedDateTime = now.copyWith(
           hour: res.hour,
           minute: res.minute,
+          second: 0,
+          millisecond: 0,
+          microsecond: 0
         );
-        if (selectedDateTime.isBefore(DateTime.now())) {
+        if (selectedDateTime.isBefore(now)) {
           selectedDateTime = selectedDateTime.add(const Duration(days: 1));
         }
       });


### PR DESCRIPTION
Changes Made
Fixed a problem in the pickTime function where setting an alarm for today would sometimes set it for tomorrow. This happened when choosing a time later than the current time. The issue was caused by mistakenly using .copyWith with selectedDateTime, which already had an extra day. I updated the logic to use DateTime.now().copyWith instead for accurate behavior in both today and tomorrow scenarios.

Problem
Previously, when users set an alarm for today and picked a later time, the alarm was mistakenly scheduled for tomorrow. This occurred when the selected time was after the current time.

Solution
Changed selectedDateTime = selectedDateTime.copyWith to selectedDateTime = DateTime.now().copyWith to fix the issue. Now, when users set alarms for today, it works correctly without adding an extra day.

I've tested it out and now it's working fine. I've also replaced if-elif-else with switch statements.