### PR TITLE
Feature/prevents int type error

### DIFF
--- a/example/lib/screens/edit_alarm.dart
+++ b/example/lib/screens/edit_alarm.dart
@@ -69,12 +69,11 @@ class _ExampleAlarmEditScreenState extends State<ExampleAlarmEditScreen> {
       setState(() {
         final DateTime now = DateTime.now();
         selectedDateTime = now.copyWith(
-          hour: res.hour,
-          minute: res.minute,
-          second: 0,
-          millisecond: 0,
-          microsecond: 0
-        );
+            hour: res.hour,
+            minute: res.minute,
+            second: 0,
+            millisecond: 0,
+            microsecond: 0);
         if (selectedDateTime.isBefore(now)) {
           selectedDateTime = selectedDateTime.add(const Duration(days: 1));
         }
@@ -83,9 +82,15 @@ class _ExampleAlarmEditScreenState extends State<ExampleAlarmEditScreen> {
   }
 
   AlarmSettings buildAlarmSettings() {
+    //[DO] id must be less than Android's max int value
     final id = creating
         ? DateTime.now().millisecondsSinceEpoch % 10000
         : widget.alarmSettings!.id;
+
+    // [DON'T] id must be less than Android's max int value
+    // final id = creating
+    //     ? DateTime.now().millisecondsSinceEpoch
+    //     : widget.alarmSettings!.id;
 
     final alarmSettings = AlarmSettings(
       id: id,

--- a/lib/model/alarm_settings.dart
+++ b/lib/model/alarm_settings.dart
@@ -91,7 +91,8 @@ class AlarmSettings {
     this.enableNotificationOnKill = true,
     this.androidFullScreenIntent = true,
   })  : assert(id != 0 && id != -1, "id cannot be set to 0 or -1"),
-        assert(id != 2147483647, "id cannot be set to Android Int.MAX_VALUE");
+        assert(id <= 2147483647,
+            "id cannot be set larger then Android Int.MAX_VALUE");
 
   /// Constructs an `AlarmSettings` instance from the given JSON data.
   factory AlarmSettings.fromJson(Map<String, dynamic> json) => AlarmSettings(

--- a/lib/model/alarm_settings.dart
+++ b/lib/model/alarm_settings.dart
@@ -90,7 +90,8 @@ class AlarmSettings {
     required this.notificationBody,
     this.enableNotificationOnKill = true,
     this.androidFullScreenIntent = true,
-  });
+  })  : assert(id != 0 && id != -1, "id cannot be set to 0 or -1"),
+        assert(id != 2147483647, "id cannot be set to Android Int.MAX_VALUE");
 
   /// Constructs an `AlarmSettings` instance from the given JSON data.
   factory AlarmSettings.fromJson(Map<String, dynamic> json) => AlarmSettings(


### PR DESCRIPTION
## Why this PullRequest is needs
When i make `AlarmSettings` model, I set `id` to timestamp of DateTime.now(). It works on iOS, but doesn't work on Android.
So, to prevent this case, I added some assertions in `AlarmSettings` model.

## Changes
- Add  two assertion in `AlarmSettings` model.
  - `assert(id != 0 && id != -1, "id cannot be set to 0 or -1")`
  - `assert(id <= 2147483647, "id cannot be set larger then Android Int.MAX_VALUE")`
- Add example case