### PR TITLE
Fix alarm id verification

### DIFF
--- a/lib/alarm.dart
+++ b/lib/alarm.dart
@@ -100,7 +100,7 @@ class Alarm {
         'Alarm id cannot be set larger than Int max value (2147483647). Provided: ${alarmSettings.id}',
       );
     }
-    if (alarmSettings.id < 2147483648) {
+    if (alarmSettings.id < -2147483648) {
       throw AlarmException(
         'Alarm id cannot be set smaller than Int min value (-2147483648). Provided: ${alarmSettings.id}',
       );


### PR DESCRIPTION
Fix Exception 'Alarm id cannot be set smaller than Int min value (-2147483648). Provided: ${alarmSettings.id}'