### PR TITLE
Fix iOS crash on stopAlarm

### DIFF
--- a/ios/Classes/SwiftAlarmPlugin.swift
+++ b/ios/Classes/SwiftAlarmPlugin.swift
@@ -389,9 +389,11 @@ public class SwiftAlarmPlugin: NSObject, FlutterPlugin {
     }
 
     private func stopNotificationOnKillService() {
-        if audioPlayers.isEmpty && observerAdded {
-            NotificationCenter.default.removeObserver(self, name: UIApplication.willTerminateNotification, object: nil)
-            observerAdded = false
+        safeModifyResources {
+            if self.audioPlayers.isEmpty && self.observerAdded {
+                NotificationCenter.default.removeObserver(self, name: UIApplication.willTerminateNotification, object: nil)
+                self.observerAdded = false
+            }
         }
     }
 


### PR DESCRIPTION
Error EXC_BAD_ACCESS

- 0: alarm: specialized Dictionary.isEmpty.getter
- 1: SwiftAlarmPlugin.stopNotificationOnKillService
- 3: SwiftAlarmPlugin.stopAlarm
- 4: ... (Other line)