### PR TITLE
fix(iOS): SwiftAlarmPlugin.scheduleAppRefresh() EXC_BAD_ACCESS

### DIFF
--- a/ios/Classes/SwiftAlarmPlugin.swift
+++ b/ios/Classes/SwiftAlarmPlugin.swift
@@ -148,8 +148,8 @@ public class SwiftAlarmPlugin: NSObject, FlutterPlugin {
 
                 DispatchQueue.main.async {
                     self.timers[id] = Timer.scheduledTimer(timeInterval: delayInSeconds, target: self, selector: #selector(self.executeTask(_:)), userInfo: id, repeats: false)
-                    SwiftAlarmPlugin.scheduleAppRefresh()
                 }
+                SwiftAlarmPlugin.scheduleAppRefresh()
             }
             result(true)
         } else {

--- a/lib/alarm.dart
+++ b/lib/alarm.dart
@@ -20,7 +20,7 @@ class Alarm {
   static bool get android => defaultTargetPlatform == TargetPlatform.android;
 
   /// Stream of the ringing status.
-  static final ringStream = StreamController<AlarmSettings>();
+  static final ringStream = StreamController<AlarmSettings>.broadcast();
 
   /// Initializes Alarm services.
   ///


### PR DESCRIPTION
```
Exception Type:  EXC_BAD_ACCESS (SIGSEGV)
Exception Subtype: UNKNOWN_0xD at 0x0000000000000000
Exception Codes: 0x000000000000000d, 0x0000000000000000

Thread 0::  Dispatch queue: com.apple.main-thread
0   libicucore.A.dylib		0x7fff214c30a2 0x7fff2139a000 + 1216674
...
19  BackgroundTasks			0x7fff4b980a4a -[BGTaskScheduler submitTaskRequest:error:] + 139
20  alarm					0x10a201585 specialized static SwiftAlarmPlugin.scheduleAppRefresh() + 309 (SwiftAlarmPlugin.swift:459)
21  alarm					0x10a1fb1c6 $s5alarm16SwiftAlarmPluginC18scheduleAppRefreshyyFZ + 5 [inlined]
22  alarm					0x10a1fb1c6 closure #2 in closure #2 in SwiftAlarmPlugin.setAlarm(call:result:) + 166 (SwiftAlarmPlugin.swift:151)
23  alarm					0x10a1f9369 thunk for @escaping @callee_guaranteed () -> () + 25
...
```