### PR TITLE
[Android] Show app on lock screen when alarm rings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.1.1
+* [Android] Show app on lock screen when alarm rings.
+
 ## 4.1.0
 * Migrated to Pigeon.
 

--- a/android/src/main/kotlin/com/gdelataillade/alarm/alarm/AlarmPlugin.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/alarm/AlarmPlugin.kt
@@ -2,10 +2,22 @@ package com.gdelataillade.alarm.alarm
 
 import AlarmApi
 import AlarmTriggerApi
+import android.app.Activity
+import android.app.KeyguardManager
+import android.content.Context
+import android.os.Build
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.Observer
 import com.gdelataillade.alarm.api.AlarmApiImpl
+import com.gdelataillade.alarm.services.AlarmRingingLiveData
+import io.flutter.Log
 import io.flutter.embedding.engine.plugins.FlutterPlugin
+import io.flutter.embedding.engine.plugins.activity.ActivityAware
+import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
 
-class AlarmPlugin : FlutterPlugin {
+class AlarmPlugin : FlutterPlugin, ActivityAware {
+    private var activity: Activity? = null
+
     companion object {
         @JvmStatic
         var alarmTriggerApi: AlarmTriggerApi? = null
@@ -14,9 +26,51 @@ class AlarmPlugin : FlutterPlugin {
     override fun onAttachedToEngine(binding: FlutterPlugin.FlutterPluginBinding) {
         AlarmApi.setUp(binding.binaryMessenger, AlarmApiImpl(binding.applicationContext))
         alarmTriggerApi = AlarmTriggerApi(binding.binaryMessenger)
+
     }
 
     override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
         alarmTriggerApi = null
+    }
+
+    override fun onAttachedToActivity(binding: ActivityPluginBinding) {
+        activity = binding.activity
+        AlarmRingingLiveData.instance.observe(
+            binding.activity as LifecycleOwner,
+            notificationObserver
+        )
+    }
+
+    override fun onDetachedFromActivity() {
+        activity = null
+        AlarmRingingLiveData.instance.removeObserver(notificationObserver)
+    }
+
+    override fun onReattachedToActivityForConfigChanges(binding: ActivityPluginBinding) {
+        onAttachedToActivity(binding)
+    }
+
+    override fun onDetachedFromActivityForConfigChanges() {
+        onDetachedFromActivity()
+    }
+
+    private val notificationObserver = Observer<Boolean> {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O_MR1) {
+            Log.w("AlarmPlugin", "Making app visible on lock screen is not supported on this version of Android.")
+            return@Observer
+        }
+        val activity = activity ?: return@Observer
+        if (it) {
+            Log.d("AlarmPlugin", "Making app visible on lock screen...")
+            activity.setShowWhenLocked(true)
+            activity.setTurnScreenOn(true)
+            val keyguardManager =
+                activity.applicationContext.getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager
+            keyguardManager.requestDismissKeyguard(activity, null)
+        } else {
+            Log.d("AlarmPlugin", "Reverting making app visible on lock screen...")
+            activity.setShowWhenLocked(false)
+            activity.setTurnScreenOn(false)
+        }
     }
 }

--- a/android/src/main/kotlin/com/gdelataillade/alarm/alarm/AlarmService.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/alarm/AlarmService.kt
@@ -17,6 +17,7 @@ import android.content.pm.ServiceInfo
 import android.os.IBinder
 import android.os.PowerManager
 import android.os.Build
+import com.gdelataillade.alarm.services.AlarmRingingLiveData
 import com.gdelataillade.alarm.services.NotificationHandler
 import io.flutter.Log
 
@@ -106,6 +107,10 @@ class AlarmService : Service() {
             return START_NOT_STICKY
         }
 
+        if (fullScreenIntent) {
+            AlarmRingingLiveData.instance.update(true)
+        }
+
         // Proceed with handling the new alarm
         val assetAudioPath = intent.getStringExtra("assetAudioPath") ?: return START_NOT_STICKY
         val loopAudio = intent.getBooleanExtra("loopAudio", true)
@@ -176,6 +181,7 @@ class AlarmService : Service() {
     }
 
     private fun stopAlarm(id: Int) {
+        AlarmRingingLiveData.instance.update(false)
         try {
             val playingIds = audioService?.getPlayingMediaPlayersIds() ?: listOf()
             ringingAlarmIds = playingIds
@@ -207,6 +213,8 @@ class AlarmService : Service() {
         vibrationService?.stopVibrating()
         volumeService?.restorePreviousVolume(showSystemUI)
         volumeService?.abandonAudioFocus()
+
+        AlarmRingingLiveData.instance.update(false)
 
         stopForeground(true)
 

--- a/android/src/main/kotlin/com/gdelataillade/alarm/services/AlarmRingingLiveData.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/services/AlarmRingingLiveData.kt
@@ -1,0 +1,14 @@
+package com.gdelataillade.alarm.services
+
+import androidx.lifecycle.LiveData
+
+class AlarmRingingLiveData : LiveData<Boolean>() {
+    companion object {
+        @JvmStatic
+        var instance: AlarmRingingLiveData = AlarmRingingLiveData()
+    }
+
+    fun update(alarmIsRinging: Boolean) {
+        postValue(alarmIsRinging)
+    }
+}

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -1,16 +1,16 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-   <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
-   <uses-permission android:name="android.permission.WAKE_LOCK"/>
-   <uses-permission android:name="android.permission.VIBRATE"/>
-   <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT"/>
-   <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-   <uses-permission android:name="android.permission.ACCESS_NOTIFICATION_POLICY" />
-   <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
-   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
-   <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK"/>
-   <uses-permission android:name="android.permission.USE_EXACT_ALARM"/>
-   <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM"/>
-   <application
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <uses-permission android:name="android.permission.VIBRATE" />
+    <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.ACCESS_NOTIFICATION_POLICY" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
+    <uses-permission android:name="android.permission.USE_EXACT_ALARM" />
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
+    <application
         android:label="alarm_example"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
@@ -22,20 +22,18 @@
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"
-            android:showWhenLocked="true"
-            android:turnScreenOn="true"
             android:windowSoftInputMode="adjustResize">
             <!-- Specifies an Android theme to apply to this Activity as soon as
                  the Android process has started. This theme is visible to the user
                  while the Flutter UI initializes. After that, this theme continues
                  to determine the Window background behind the Flutter UI. -->
             <meta-data
-              android:name="io.flutter.embedding.android.NormalTheme"
-              android:resource="@style/NormalTheme"
-              />
+                android:name="io.flutter.embedding.android.NormalTheme"
+                android:resource="@style/NormalTheme"
+            />
             <intent-filter>
-                <action android:name="android.intent.action.MAIN"/>
-                <category android:name="android.intent.category.LAUNCHER"/>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.

--- a/example/lib/screens/home.dart
+++ b/example/lib/screens/home.dart
@@ -9,7 +9,7 @@ import 'package:alarm_example/widgets/tile.dart';
 import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-const version = '4.1.0';
+const version = '4.1.1';
 
 class ExampleAlarmHomeScreen extends StatefulWidget {
   const ExampleAlarmHomeScreen({super.key});

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -211,10 +211,10 @@ packages:
     dependency: transitive
     description:
       name: permission_handler_html
-      sha256: af26edbbb1f2674af65a8f4b56e1a6f526156bc273d0e65dd8075fab51c78851
+      sha256: "38f000e83355abb3392140f6bc3030660cfaef189e1f87824facb76300b4ff24"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.3+2"
+    version: "0.1.3+5"
   permission_handler_platform_interface:
     dependency: transitive
     description:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "4.1.0"
+    version: "4.1.1"
   async:
     dependency: transitive
     description:
@@ -259,10 +259,10 @@ packages:
     dependency: transitive
     description:
       name: shared_preferences_android
-      sha256: "3b9febd815c9ca29c9e3520d50ec32f49157711e143b7a4ca039eb87e8ade5ab"
+      sha256: "7f172d1b06de5da47b6264c2692ee2ead20bbbc246690427cdb4fc301cd0c549"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.3"
+    version: "2.3.4"
   shared_preferences_foundation:
     dependency: transitive
     description:

--- a/help/INSTALL-ANDROID.md
+++ b/help/INSTALL-ANDROID.md
@@ -35,15 +35,6 @@ Then, add the following permissions to your `AndroidManifest.xml` within the `<m
 See more details on Android permissions [here](https://developer.android.com/reference/android/Manifest.permission).
 
 ## Step 3
-Finally, if you want your notifications to show in full screen even when the device is locked (`androidFullScreenIntent` parameter), add these attributes in `<activity>`:
-
-```xml
-<activity
-    android:showWhenLocked="true"
-    android:turnScreenOn="true">
-```
-
-## Step 4
 Inside the <application> tag of your `AndroidManifest.xml`, add the following declarations (if you need notification-on-kill feature):
 ```xml
 <application>
@@ -55,7 +46,7 @@ Inside the <application> tag of your `AndroidManifest.xml`, add the following de
 
 Necessary if you want to enable an optional notification with `Alarm.setWarningNotificationOnKill` to alert users if the app is terminated, hinting at a rare chance the alarm may not work.
 
-## Step 5
+## Step 4
 To guarantee that your alarm's foreground service can trigger when the app is in the background, it's recommanded to verify and request the necessary permission for scheduling exact alarms on Android 12+ devices. This step is particularly important due to varying device policies.
 
 Leverage the [permission_handler](https://pub.dev/packages/permission_handler) package to check and request this permission seamlessly within your Flutter application. Here's an example to integrate into your code:
@@ -72,7 +63,7 @@ Future<void> checkAndroidScheduleExactAlarmPermission() async {
 }
 ```
 
-## Step 6
+## Step 5
 If you want to use the `androidFullScreenIntent` feature, some OEM (Samsung, Honor, Huawei, Xiaomi, Oppo, Asus, etc...) will require to grant the [auto_start_flutter](https://pub.dev/packages/auto_start_flutter) permission.
 
 ## Additional Resources

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: alarm
 description: A simple Flutter alarm manager plugin for both iOS and Android.
-version: 4.1.0
+version: 4.1.1
 homepage: https://github.com/gdelataillade/alarm
 
 environment:
@@ -17,7 +17,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  pigeon: ^22.6.1
+  pigeon: ^22.6.2
   very_good_analysis: ^6.0.0
 
 flutter:


### PR DESCRIPTION
The current Android instructions result in the app being shown on the lock-screen permanently. This is likely not desired by all apps.

This PR dynamically shows the app on the lock-screen and turns the screen on when an alarm rings AND reverts showing the app on the lock-screen once the alarm is stopped.

This PR is branched from https://github.com/gdelataillade/alarm/pull/292, please see [this commit](https://github.com/gdelataillade/alarm/pull/294/commits/6ada0429730a1209a609f190084d0cae900d703f) for diffs.