### PR TITLE
Implement stopAll natively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Add support for fading the alarm volume using a staircase function.
 * Fixes a bug where `isRinging` might return FALSE immediately after alarm starts to ring.
 * Handles alarm events on the platform side, increasing efficiency.
+* Handles `stopAll` on the platform side for improved reliability.
 
 ## 4.1.1
 * [Android] Show app on lock screen when alarm rings.

--- a/android/src/main/kotlin/com/gdelataillade/alarm/api/AlarmApiImpl.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/api/AlarmApiImpl.kt
@@ -58,6 +58,15 @@ class AlarmApiImpl(private val context: Context) : AlarmApi {
         }
     }
 
+    override fun stopAll() {
+        for (alarm in AlarmStorage(context).getSavedAlarms()) {
+            stopAlarm(alarm.id.toLong())
+        }
+        for (alarmId in alarmIds.toList()) {
+            stopAlarm(alarmId.toLong())
+        }
+    }
+
     override fun isRinging(alarmId: Long?): Boolean {
         val ringingAlarmIds = AlarmService.ringingAlarmIds
         if (alarmId == null) {

--- a/android/src/main/kotlin/com/gdelataillade/alarm/api/AlarmApiImpl.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/api/AlarmApiImpl.kt
@@ -62,7 +62,8 @@ class AlarmApiImpl(private val context: Context) : AlarmApi {
         for (alarm in AlarmStorage(context).getSavedAlarms()) {
             stopAlarm(alarm.id.toLong())
         }
-        for (alarmId in alarmIds.toList()) {
+        val alarmIdsCopy = alarmIds.toList()
+        for (alarmId in alarmIdsCopy) {
             stopAlarm(alarmId.toLong())
         }
     }

--- a/android/src/main/kotlin/com/gdelataillade/alarm/generated/FlutterBindings.g.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/generated/FlutterBindings.g.kt
@@ -251,6 +251,7 @@ private open class FlutterBindingsPigeonCodec : StandardMessageCodec() {
 interface AlarmApi {
   fun setAlarm(alarmSettings: AlarmSettingsWire)
   fun stopAlarm(alarmId: Long)
+  fun stopAll()
   fun isRinging(alarmId: Long?): Boolean
   fun setWarningNotificationOnKill(title: String, body: String)
   fun disableWarningNotificationOnKill()
@@ -290,6 +291,22 @@ interface AlarmApi {
             val alarmIdArg = args[0] as Long
             val wrapped: List<Any?> = try {
               api.stopAlarm(alarmIdArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              wrapError(exception)
+            }
+            reply.reply(wrapped)
+          }
+        } else {
+          channel.setMessageHandler(null)
+        }
+      }
+      run {
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.alarm.AlarmApi.stopAll$separatedMessageChannelSuffix", codec)
+        if (api != null) {
+          channel.setMessageHandler { _, reply ->
+            val wrapped: List<Any?> = try {
+              api.stopAll()
               listOf(null)
             } catch (exception: Throwable) {
               wrapError(exception)

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -4,6 +4,8 @@ PODS:
   - Flutter (1.0.0)
   - flutter_fgbg (0.0.1):
     - Flutter
+  - package_info_plus (0.4.5):
+    - Flutter
   - permission_handler_apple (9.3.0):
     - Flutter
   - shared_preferences_foundation (0.0.1):
@@ -16,6 +18,7 @@ DEPENDENCIES:
   - alarm (from `.symlinks/plugins/alarm/ios`)
   - Flutter (from `Flutter`)
   - flutter_fgbg (from `.symlinks/plugins/flutter_fgbg/ios`)
+  - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
   - permission_handler_apple (from `.symlinks/plugins/permission_handler_apple/ios`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
   - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
@@ -27,6 +30,8 @@ EXTERNAL SOURCES:
     :path: Flutter
   flutter_fgbg:
     :path: ".symlinks/plugins/flutter_fgbg/ios"
+  package_info_plus:
+    :path: ".symlinks/plugins/package_info_plus/ios"
   permission_handler_apple:
     :path: ".symlinks/plugins/permission_handler_apple/ios"
   shared_preferences_foundation:
@@ -38,6 +43,7 @@ SPEC CHECKSUMS:
   alarm: 6c1f6a9688f94cd6bf8f104c67cc26e78c9d8d13
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   flutter_fgbg: 31c0d1140a131daea2d342121808f6aa0dcd879d
+  package_info_plus: c0502532a26c7662a62a356cebe2692ec5fe4ec4
   permission_handler_apple: 9878588469a2b0d0fc1e048d9f43605f92e6cec2
   shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
   url_launcher_ios: 5334b05cef931de560670eeae103fd3e431ac3fe

--- a/example/lib/screens/home.dart
+++ b/example/lib/screens/home.dart
@@ -131,6 +131,16 @@ class _ExampleAlarmHomeScreenState extends State<ExampleAlarmHomeScreen> {
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
             ExampleAlarmHomeShortcutButton(refreshAlarms: loadAlarms),
+            const FloatingActionButton(
+              onPressed: Alarm.stopAll,
+              backgroundColor: Colors.red,
+              heroTag: null,
+              child: Text(
+                'STOP ALL',
+                textScaler: TextScaler.linear(0.9),
+                textAlign: TextAlign.center,
+              ),
+            ),
             FloatingActionButton(
               onPressed: () => navigateToAlarmScreen(null),
               child: const Icon(Icons.alarm_add_rounded, size: 33),

--- a/example/lib/screens/shortcut_button.dart
+++ b/example/lib/screens/shortcut_button.dart
@@ -60,9 +60,13 @@ class _ExampleAlarmHomeShortcutButtonState
           },
           child: FloatingActionButton(
             onPressed: () => onPressButton(0),
-            backgroundColor: Colors.red,
+            backgroundColor: Colors.green[700],
             heroTag: null,
-            child: const Text('RING NOW', textAlign: TextAlign.center),
+            child: const Text(
+              'RING NOW',
+              textScaler: TextScaler.linear(0.9),
+              textAlign: TextAlign.center,
+            ),
           ),
         ),
         if (showMenu)

--- a/ios/Classes/generated/FlutterBindings.g.swift
+++ b/ios/Classes/generated/FlutterBindings.g.swift
@@ -144,7 +144,6 @@ struct VolumeSettingsWire {
   var volumeEnforced: Bool
 
 
-
   // swift-format-ignore: AlwaysUseLowerCamelCase
   static func fromList(_ pigeonVar_list: [Any?]) -> VolumeSettingsWire? {
     let volume: Double? = nilOrValue(pigeonVar_list[0])
@@ -173,7 +172,6 @@ struct VolumeSettingsWire {
 struct VolumeFadeStepWire {
   var timeMillis: Int64
   var volume: Double
-
 
 
   // swift-format-ignore: AlwaysUseLowerCamelCase
@@ -290,6 +288,7 @@ class FlutterBindingsPigeonCodec: FlutterStandardMessageCodec, @unchecked Sendab
 protocol AlarmApi {
   func setAlarm(alarmSettings: AlarmSettingsWire) throws
   func stopAlarm(alarmId: Int64) throws
+  func stopAll() throws
   func isRinging(alarmId: Int64?) throws -> Bool
   func setWarningNotificationOnKill(title: String, body: String) throws
   func disableWarningNotificationOnKill() throws
@@ -330,6 +329,19 @@ class AlarmApiSetup {
       }
     } else {
       stopAlarmChannel.setMessageHandler(nil)
+    }
+    let stopAllChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.alarm.AlarmApi.stopAll\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      stopAllChannel.setMessageHandler { _, reply in
+        do {
+          try api.stopAll()
+          reply(wrapResult(nil))
+        } catch {
+          reply(wrapError(error))
+        }
+      }
+    } else {
+      stopAllChannel.setMessageHandler(nil)
     }
     let isRingingChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.alarm.AlarmApi.isRinging\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {

--- a/ios/Classes/services/NotificationManager.swift
+++ b/ios/Classes/services/NotificationManager.swift
@@ -74,6 +74,11 @@ class NotificationManager: NSObject, UNUserNotificationCenterDelegate {
         let notificationIdentifier = "alarm-\(id)"
         UNUserNotificationCenter.current().removeDeliveredNotifications(withIdentifiers: [notificationIdentifier])
     }
+    
+    func removeAllNotifications() {
+        UNUserNotificationCenter.current().removeAllPendingNotificationRequests()
+        UNUserNotificationCenter.current().removeAllDeliveredNotifications()
+    }
 
     func handleAction(withIdentifier identifier: String?, for notification: UNNotification) {
         guard let identifier = identifier else { return }

--- a/lib/alarm.dart
+++ b/lib/alarm.dart
@@ -152,8 +152,12 @@ class Alarm {
   static Future<void> stopAll() async {
     final alarms = await getAlarms();
 
+    iOS ? await IOSAlarm.stopAll() : await AndroidAlarm.stopAll();
+
+    await AlarmStorage.unsaveAll();
+
     for (final alarm in alarms) {
-      await stop(alarm.id);
+      updateStream.add(alarm.id);
     }
   }
 

--- a/lib/service/alarm_storage.dart
+++ b/lib/service/alarm_storage.dart
@@ -64,6 +64,18 @@ class AlarmStorage {
     await _prefs.remove('$prefix$id');
   }
 
+  /// Removes all alarms from local storage.
+  static Future<void> unsaveAll() async {
+    await _waitUntilInitialized();
+
+    final keys = _prefs.getKeys();
+    for (final key in keys) {
+      if (key.startsWith(prefix)) {
+        await _prefs.remove(key);
+      }
+    }
+  }
+
   /// Whether at least one alarm is set.
   static Future<bool> hasAlarm() async {
     await _waitUntilInitialized();

--- a/lib/src/android_alarm.dart
+++ b/lib/src/android_alarm.dart
@@ -41,6 +41,11 @@ class AndroidAlarm {
     }
   }
 
+  /// Calls the native `stopAll` function.
+  static Future<void> stopAll() async {
+    return _api.stopAll().catchError(AlarmExceptionHandlers.catchError<void>);
+  }
+
   /// Checks whether an alarm or any alarm (if id is null) is ringing.
   static Future<bool> isRinging([int? id]) async {
     try {

--- a/lib/src/generated/platform_bindings.g.dart
+++ b/lib/src/generated/platform_bindings.g.dart
@@ -314,6 +314,30 @@ class AlarmApi {
     }
   }
 
+  Future<void> stopAll() async {
+    final String pigeonVar_channelName =
+        'dev.flutter.pigeon.alarm.AlarmApi.stopAll$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel =
+        BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_channel.send(null) as List<Object?>?;
+    if (pigeonVar_replyList == null) {
+      throw _createConnectionError(pigeonVar_channelName);
+    } else if (pigeonVar_replyList.length > 1) {
+      throw PlatformException(
+        code: pigeonVar_replyList[0]! as String,
+        message: pigeonVar_replyList[1] as String?,
+        details: pigeonVar_replyList[2],
+      );
+    } else {
+      return;
+    }
+  }
+
   Future<bool> isRinging({required int? alarmId}) async {
     final String pigeonVar_channelName =
         'dev.flutter.pigeon.alarm.AlarmApi.isRinging$pigeonVar_messageChannelSuffix';

--- a/lib/src/ios_alarm.dart
+++ b/lib/src/ios_alarm.dart
@@ -31,7 +31,6 @@ class IOSAlarm {
     return true;
   }
 
-  /// Disposes timer and FGBG subscription
   /// and calls the native `stopAlarm` function.
   static Future<bool> stopAlarm(int id) async {
     try {
@@ -44,6 +43,11 @@ class IOSAlarm {
       alarmPrint('Failed to stop alarm $id. $e');
       return false;
     }
+  }
+
+  /// Calls the native `stopAll` function.
+  static Future<void> stopAll() async {
+    return _api.stopAll().catchError(AlarmExceptionHandlers.catchError<void>);
   }
 
   /// Checks whether an alarm or any alarm (if id is null) is ringing.

--- a/pigeons/alarm_api.dart
+++ b/pigeons/alarm_api.dart
@@ -103,6 +103,8 @@ abstract class AlarmApi {
 
   void stopAlarm({required int alarmId});
 
+  void stopAll();
+
   bool isRinging({required int? alarmId});
 
   void setWarningNotificationOnKill({


### PR DESCRIPTION
Having native support for the `stopAll` function should increase reliability since it will ensure all alarms saved on the platform side (Swift, Kotlin) are cleaned up.