### PR TITLE
Hotfix build error due to merge conflict

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -56,8 +56,10 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.datastore:datastore:1.1.1'
-    implementation 'androidx.datastore:datastore-preferences:1.1.1'
+    //noinspection v1.1.1 has a bug that prevents native_debug_symbol generation
+    //             see: https://issuetracker.google.com/u/0/issues/342671895
+    implementation 'androidx.datastore:datastore:1.0.0'
+    implementation 'androidx.datastore:datastore-preferences:1.0.0'
     //noinspection GradleDependency: 1.7+ requires Kotlin 2
     implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3'
 }

--- a/android/src/main/kotlin/com/gdelataillade/alarm/models/AlarmSettings.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/models/AlarmSettings.kt
@@ -1,7 +1,7 @@
 package com.gdelataillade.alarm.models
 
 import com.gdelataillade.alarm.generated.AlarmSettingsWire
-import com.google.gson.*
+import kotlinx.serialization.KSerializer
 import java.util.Date
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.descriptors.PrimitiveKind

--- a/android/src/main/kotlin/com/gdelataillade/alarm/models/NotificationSettings.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/models/NotificationSettings.kt
@@ -1,7 +1,7 @@
 package com.gdelataillade.alarm.models
 
 import com.gdelataillade.alarm.generated.NotificationSettingsWire
-import com.google.gson.Gson
+import kotlinx.serialization.Serializable
 
 @Serializable
 data class NotificationSettings(

--- a/android/src/main/kotlin/com/gdelataillade/alarm/models/VolumeSettings.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/models/VolumeSettings.kt
@@ -1,7 +1,7 @@
 package com.gdelataillade.alarm.models
 
-import VolumeFadeStepWire
-import VolumeSettingsWire
+import com.gdelataillade.alarm.generated.VolumeFadeStepWire
+import com.gdelataillade.alarm.generated.VolumeSettingsWire
 import kotlinx.serialization.Serializable
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds


### PR DESCRIPTION
This PR also fixes an issue with Android native debug symbols not being shipped with the appbundle.