### PR TITLE
fix for #311

### DIFF
--- a/android/src/main/kotlin/com/gdelataillade/alarm/alarm/AlarmPlugin.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/alarm/AlarmPlugin.kt
@@ -11,6 +11,7 @@ import androidx.lifecycle.Observer
 import com.gdelataillade.alarm.api.AlarmApiImpl
 import com.gdelataillade.alarm.services.AlarmRingingLiveData
 import io.flutter.Log
+import io.flutter.embedding.engine.dart.DartExecutor
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.embedding.engine.plugins.activity.ActivityAware
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
@@ -19,18 +20,30 @@ class AlarmPlugin : FlutterPlugin, ActivityAware {
     private var activity: Activity? = null
 
     companion object {
+        private var mainEngine: DartExecutor? = null
+        
         @JvmStatic
         var alarmTriggerApi: AlarmTriggerApi? = null
     }
 
     override fun onAttachedToEngine(binding: FlutterPlugin.FlutterPluginBinding) {
-        AlarmApi.setUp(binding.binaryMessenger, AlarmApiImpl(binding.applicationContext))
-        alarmTriggerApi = AlarmTriggerApi(binding.binaryMessenger)
+        val engine = binding.binaryMessenger as DartExecutor
+        if (mainEngine == null) {
+            // If this is our first engine, consider it the main one
+            mainEngine = engine
+            AlarmApi.setUp(binding.binaryMessenger, AlarmApiImpl(binding.applicationContext))
+            alarmTriggerApi = AlarmTriggerApi(binding.binaryMessenger)
 
+        }
     }
 
     override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
-        alarmTriggerApi = null
+        val engine = binding.binaryMessenger as DartExecutor
+        
+        if (engine == mainEngine) {
+            mainEngine = null
+            alarmTriggerApi = null
+        }
     }
 
     override fun onAttachedToActivity(binding: ActivityPluginBinding) {


### PR DESCRIPTION
The alarm listener doesn't fire if app is in foreground (Android only) 

The problem is a collision between Alarm and Firebase Cloud Messaging. When I retrieve my FCM token, it starts a new background isolate. Alarm, seeing this new engine, attaches to it, instead of the main engine. And this means that Alarm can no longer send messages to the app, so the listener fails. This fix adds a check to ensure that we only attach to the main engine, and not any subsequent isolates.