### PR TITLE
Android - Stop alarm on notification dismiss

### DIFF
--- a/android/src/main/kotlin/com/gdelataillade/alarm/services/NotificationService.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/services/NotificationService.kt
@@ -80,6 +80,7 @@ class NotificationHandler(private val context: Context) {
             .setAutoCancel(true)
             .setOngoing(true)
             .setContentIntent(pendingIntent)
+            .setDeleteIntent(stopPendingIntent)
             .setSound(null)
             .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
 


### PR DESCRIPTION
I noticed when notification is dismissed there isn't a way to stop the alarm unless through a patch in the app. This could be a big issue, so why not stop it when swiped away/dismissed the same way as the stop button