### PR TITLE
Keep notification after alarm ends

### DIFF
--- a/android/src/main/kotlin/com/gdelataillade/alarm/generated/FlutterBindings.g.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/generated/FlutterBindings.g.kt
@@ -174,7 +174,8 @@ data class NotificationSettingsWire (
   val title: String,
   val body: String,
   val stopButton: String? = null,
-  val icon: String? = null
+  val icon: String? = null,
+  val keepNotificationAfterAlarmEnds: Boolean
 )
  {
   companion object {
@@ -183,7 +184,8 @@ data class NotificationSettingsWire (
       val body = pigeonVar_list[1] as String
       val stopButton = pigeonVar_list[2] as String?
       val icon = pigeonVar_list[3] as String?
-      return NotificationSettingsWire(title, body, stopButton, icon)
+      val keepNotificationAfterAlarmEnds = pigeonVar_list[4] as Boolean
+      return NotificationSettingsWire(title, body, stopButton, icon, keepNotificationAfterAlarmEnds)
     }
   }
   fun toList(): List<Any?> {
@@ -192,6 +194,7 @@ data class NotificationSettingsWire (
       body,
       stopButton,
       icon,
+      keepNotificationAfterAlarmEnds,
     )
   }
 }

--- a/android/src/main/kotlin/com/gdelataillade/alarm/models/NotificationSettings.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/models/NotificationSettings.kt
@@ -8,8 +8,7 @@ data class NotificationSettings(
     val title: String,
     val body: String,
     val stopButton: String? = null,
-    val icon: String? = null,
-    val keepNotificationAfterAlarmEnds: Boolean = false
+    val icon: String? = null
 ) {
     companion object {
         fun fromWire(e: NotificationSettingsWire): NotificationSettings {
@@ -17,8 +16,7 @@ data class NotificationSettings(
                 e.title,
                 e.body,
                 e.stopButton,
-                e.icon,
-                e.keepNotificationAfterAlarmEnds ?: false
+                e.icon
             )
         }
     }

--- a/android/src/main/kotlin/com/gdelataillade/alarm/models/NotificationSettings.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/models/NotificationSettings.kt
@@ -8,7 +8,8 @@ data class NotificationSettings(
     val title: String,
     val body: String,
     val stopButton: String? = null,
-    val icon: String? = null
+    val icon: String? = null,
+    val keepNotificationAfterAlarmEnds: Boolean = false
 ) {
     companion object {
         fun fromWire(e: NotificationSettingsWire): NotificationSettings {
@@ -17,6 +18,7 @@ data class NotificationSettings(
                 e.body,
                 e.stopButton,
                 e.icon,
+                e.keepNotificationAfterAlarmEnds ?: false
             )
         }
     }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -12,42 +12,42 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.12.0"
+    version: "2.11.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      sha256: "8aab1771e1243a5063b8b0ff68042d67334e3feab9e95b9490f9a6ebf73b42ea"
+      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.1"
   characters:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.3.0"
   clock:
     dependency: transitive
     description:
       name: clock
-      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
+      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.2"
+    version: "1.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
+      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
       url: "https://pub.dev"
     source: hosted
-    version: "1.19.1"
+    version: "1.19.0"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -68,10 +68,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
+      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.3.1"
   ffi:
     dependency: transitive
     description:
@@ -131,18 +131,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
+      sha256: "7bb2830ebd849694d1ec25bf1f44582d6ac531a57a365a803a6034ff751d2d06"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.8"
+    version: "10.0.7"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      sha256: "9491a714cca3667b60b5c420da8217e6de0d1ba7a5ec322fab01758f6998f379"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.8"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -163,10 +163,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
@@ -179,18 +179,18 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.15.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.9.0"
   path_provider_linux:
     dependency: transitive
     description:
@@ -352,50 +352,50 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c"
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.1"
+    version: "1.10.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
+      sha256: "9f47fd3630d76be3ab26f0ee06d213679aa425996925ff3feffdec504931c377"
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.1"
+    version: "1.12.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.2"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "921cd31725b72fe181906c6a94d987c78e3b98c2e205b397ea399d4054872b43"
+      sha256: "688af5ed3402a4bde5b3a6c15fd768dbf2621a614950b17f04626c431ab3c4c3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.3.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      sha256: "7f554798625ea768a7518313e58f83891c7f5024f88e46e7182a4558850a4b8e"
+      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.2"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.3"
   url_launcher:
     dependency: "direct main"
     description:
@@ -480,10 +480,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
+      sha256: f6be3ed8bd01289b34d679c2b62226f63c0e69f9fd2e50a6b3c1c729a961041b
       url: "https://pub.dev"
     source: hosted
-    version: "14.3.1"
+    version: "14.3.0"
   web:
     dependency: transitive
     description:
@@ -501,5 +501,5 @@ packages:
     source: hosted
     version: "1.1.0"
 sdks:
-  dart: ">=3.7.0-0 <4.0.0"
+  dart: ">=3.6.0 <4.0.0"
   flutter: ">=3.27.0"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -12,42 +12,42 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
+      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
       url: "https://pub.dev"
     source: hosted
-    version: "2.11.0"
+    version: "2.12.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      sha256: "8aab1771e1243a5063b8b0ff68042d67334e3feab9e95b9490f9a6ebf73b42ea"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   characters:
     dependency: transitive
     description:
       name: characters
-      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.0"
   clock:
     dependency: transitive
     description:
       name: clock
-      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
       url: "https://pub.dev"
     source: hosted
-    version: "1.19.0"
+    version: "1.19.1"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -68,10 +68,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.2"
   ffi:
     dependency: transitive
     description:
@@ -97,10 +97,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_fgbg
-      sha256: e02ad0738ba5fc7f331b62acb0d74aa540626a6441ae18fad685faa5ac4ad7a5
+      sha256: eb6da9b2047372566a6e17b505975fe5bace94af01f6fc825c4b6f81baa6c447
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.0"
+    version: "0.7.1"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -131,18 +131,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7bb2830ebd849694d1ec25bf1f44582d6ac531a57a365a803a6034ff751d2d06"
+      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.7"
+    version: "10.0.8"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "9491a714cca3667b60b5c420da8217e6de0d1ba7a5ec322fab01758f6998f379"
+      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.8"
+    version: "3.0.9"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -163,10 +163,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16+1"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
@@ -179,18 +179,18 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
+      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   path_provider_linux:
     dependency: transitive
     description:
@@ -352,50 +352,50 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
+      sha256: "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.10.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "9f47fd3630d76be3ab26f0ee06d213679aa425996925ff3feffdec504931c377"
+      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.12.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
+      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "688af5ed3402a4bde5b3a6c15fd768dbf2621a614950b17f04626c431ab3c4c3"
+      sha256: "921cd31725b72fe181906c6a94d987c78e3b98c2e205b397ea399d4054872b43"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      sha256: "7f554798625ea768a7518313e58f83891c7f5024f88e46e7182a4558850a4b8e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
+      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.3"
+    version: "0.7.4"
   url_launcher:
     dependency: "direct main"
     description:
@@ -480,10 +480,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: f6be3ed8bd01289b34d679c2b62226f63c0e69f9fd2e50a6b3c1c729a961041b
+      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
       url: "https://pub.dev"
     source: hosted
-    version: "14.3.0"
+    version: "14.3.1"
   web:
     dependency: transitive
     description:
@@ -501,5 +501,5 @@ packages:
     source: hosted
     version: "1.1.0"
 sdks:
-  dart: ">=3.6.0 <4.0.0"
+  dart: ">=3.7.0-0 <4.0.0"
   flutter: ">=3.27.0"

--- a/ios/Classes/api/AlarmApiImpl.swift
+++ b/ios/Classes/api/AlarmApiImpl.swift
@@ -414,7 +414,7 @@ public class AlarmApiImpl: NSObject, AlarmApi {
         if cancelNotif {
             NotificationManager.shared.cancelNotification(id: id)
         }
-        NotificationManager.shared.dismissNotification(id: id)
+        // NotificationManager.shared.dismissNotification(id: id)
 
         self.mixOtherAudios()
 

--- a/ios/Classes/api/AlarmApiImpl.swift
+++ b/ios/Classes/api/AlarmApiImpl.swift
@@ -411,10 +411,14 @@ public class AlarmApiImpl: NSObject, AlarmApi {
     }
 
     private func stopAlarmInternal(id: Int, cancelNotif: Bool) {
+        guard let alarm = self.alarms[id] else { return }
+        
         if cancelNotif {
             NotificationManager.shared.cancelNotification(id: id)
         }
-        // NotificationManager.shared.dismissNotification(id: id)
+        if !alarm.settings.notificationSettings.keepNotificationAfterAlarmEnds {
+            NotificationManager.shared.dismissNotification(id: id)
+        }
 
         self.mixOtherAudios()
 
@@ -424,17 +428,15 @@ public class AlarmApiImpl: NSObject, AlarmApi {
             self.setVolume(volume: previousVolume, enable: false)
         }
 
-        if let alarm = self.alarms[id] {
-            alarm.timer?.invalidate()
-            alarm.timer = nil
-            alarm.task?.cancel()
-            alarm.task = nil
-            alarm.audioPlayer?.stop()
-            alarm.audioPlayer = nil
-            alarm.volumeEnforcementTimer?.invalidate()
-            alarm.volumeEnforcementTimer = nil
-            self.alarms.removeValue(forKey: id)
-        }
+        alarm.timer?.invalidate()
+        alarm.timer = nil
+        alarm.task?.cancel()
+        alarm.task = nil
+        alarm.audioPlayer?.stop()
+        alarm.audioPlayer = nil
+        alarm.volumeEnforcementTimer?.invalidate()
+        alarm.volumeEnforcementTimer = nil
+        self.alarms.removeValue(forKey: id)
 
         self.stopSilentSound()
         self.stopNotificationOnKillService()

--- a/ios/Classes/generated/FlutterBindings.g.swift
+++ b/ios/Classes/generated/FlutterBindings.g.swift
@@ -206,6 +206,7 @@ struct NotificationSettingsWire {
   var body: String
   var stopButton: String? = nil
   var icon: String? = nil
+  var keepNotificationAfterAlarmEnds: Bool
 
 
   // swift-format-ignore: AlwaysUseLowerCamelCase
@@ -214,12 +215,14 @@ struct NotificationSettingsWire {
     let body = pigeonVar_list[1] as! String
     let stopButton: String? = nilOrValue(pigeonVar_list[2])
     let icon: String? = nilOrValue(pigeonVar_list[3])
+    let keepNotificationAfterAlarmEnds = pigeonVar_list[4] as! Bool
 
     return NotificationSettingsWire(
       title: title,
       body: body,
       stopButton: stopButton,
-      icon: icon
+      icon: icon,
+      keepNotificationAfterAlarmEnds: keepNotificationAfterAlarmEnds
     )
   }
   func toList() -> [Any?] {
@@ -228,6 +231,7 @@ struct NotificationSettingsWire {
       body,
       stopButton,
       icon,
+      keepNotificationAfterAlarmEnds,
     ]
   }
 }

--- a/ios/Classes/models/NotificationSettings.swift
+++ b/ios/Classes/models/NotificationSettings.swift
@@ -4,6 +4,7 @@ struct NotificationSettings: Codable {
     var title: String
     var body: String
     var stopButton: String?
+    var keepNotificationAfterAlarmEnds: Bool = false
 
     static func from(wire: NotificationSettingsWire) -> NotificationSettings {
         // NotificationSettingsWire.icon is ignored since we can't modify the
@@ -11,7 +12,8 @@ struct NotificationSettings: Codable {
         return NotificationSettings(
             title: wire.title,
             body: wire.body,
-            stopButton: wire.stopButton
+            stopButton: wire.stopButton,
+            keepNotificationAfterAlarmEnds: wire.keepNotificationAfterAlarmEnds ?? false
         )
     }
 
@@ -19,7 +21,8 @@ struct NotificationSettings: Codable {
         return NotificationSettings(
             title: json["title"] as! String,
             body: json["body"] as! String,
-            stopButton: json["stopButton"] as? String
+            stopButton: json["stopButton"] as? String,
+            keepNotificationAfterAlarmEnds: json["keepNotificationAfterAlarmEnds"] as? Bool ?? false
         )
     }
 
@@ -27,7 +30,8 @@ struct NotificationSettings: Codable {
         return [
             "title": notificationSettings.title,
             "body": notificationSettings.body,
-            "stopButton": notificationSettings.stopButton as Any
+            "stopButton": notificationSettings.stopButton as Any,
+            "keepNotificationAfterAlarmEnds": notificationSettings.keepNotificationAfterAlarmEnds
         ]
     }
 }

--- a/ios/Classes/models/NotificationSettings.swift
+++ b/ios/Classes/models/NotificationSettings.swift
@@ -13,7 +13,7 @@ struct NotificationSettings: Codable {
             title: wire.title,
             body: wire.body,
             stopButton: wire.stopButton,
-            keepNotificationAfterAlarmEnds: wire.keepNotificationAfterAlarmEnds ?? false
+            keepNotificationAfterAlarmEnds: wire.keepNotificationAfterAlarmEnds
         )
     }
 
@@ -22,7 +22,7 @@ struct NotificationSettings: Codable {
             title: json["title"] as! String,
             body: json["body"] as! String,
             stopButton: json["stopButton"] as? String,
-            keepNotificationAfterAlarmEnds: json["keepNotificationAfterAlarmEnds"] as? Bool ?? false
+            keepNotificationAfterAlarmEnds: json["keepNotificationAfterAlarmEnds"] as! Bool 
         )
     }
 

--- a/lib/model/notification_settings.dart
+++ b/lib/model/notification_settings.dart
@@ -62,7 +62,7 @@ class NotificationSettings extends Equatable {
   /// **iOS only feature - has no effect on Android.**
   ///
   /// If set to `true`, the notification will remain visible in the notification
-  /// center even after the alarm has been stopped or dismissed.
+  /// center even after the alarm sound ends.
   /// If `false`, the notification will be automatically removed when
   /// the alarm sound ends.
   ///

--- a/lib/model/notification_settings.dart
+++ b/lib/model/notification_settings.dart
@@ -104,6 +104,11 @@ class NotificationSettings extends Equatable {
   }
 
   @override
-  List<Object?> get props =>
-      [title, body, stopButton, icon, keepNotificationAfterAlarmEnds];
+  List<Object?> get props => [
+        title,
+        body,
+        stopButton,
+        icon,
+        keepNotificationAfterAlarmEnds,
+      ];
 }

--- a/lib/model/notification_settings.dart
+++ b/lib/model/notification_settings.dart
@@ -15,6 +15,7 @@ class NotificationSettings extends Equatable {
     required this.body,
     this.stopButton,
     this.icon,
+    this.keepNotificationAfterAlarmEnds = false,
   });
 
   /// Converts the JSON object to a `NotificationSettings` instance.
@@ -56,6 +57,18 @@ class NotificationSettings extends Equatable {
   /// Defaults to `null`.
   final String? icon;
 
+  /// Whether to keep the notification visible after the alarm sound ends.
+  ///
+  /// **iOS only feature - has no effect on Android.**
+  ///
+  /// If set to `true`, the notification will remain visible in the notification
+  /// center even after the alarm has been stopped or dismissed.
+  /// If `false`, the notification will be automatically removed when
+  /// the alarm sound ends.
+  ///
+  /// Defaults to `false`.
+  final bool keepNotificationAfterAlarmEnds;
+
   /// Converts the `NotificationSettings` instance to a JSON object.
   Map<String, dynamic> toJson() => _$NotificationSettingsToJson(this);
 
@@ -65,6 +78,7 @@ class NotificationSettings extends Equatable {
         body: body,
         stopButton: stopButton,
         icon: icon,
+        keepNotificationAfterAlarmEnds: keepNotificationAfterAlarmEnds,
       );
 
   /// Creates a copy of this notification settings but with the given fields
@@ -74,6 +88,7 @@ class NotificationSettings extends Equatable {
     String? body,
     String? stopButton,
     String? icon,
+    bool? keepNotificationAfterAlarmEnds,
   }) {
     assert(title != null, 'NotificationSettings.title cannot be null');
     assert(body != null, 'NotificationSettings.body cannot be null');
@@ -83,9 +98,12 @@ class NotificationSettings extends Equatable {
       body: body ?? this.body,
       stopButton: stopButton ?? this.stopButton,
       icon: icon ?? this.icon,
+      keepNotificationAfterAlarmEnds:
+          keepNotificationAfterAlarmEnds ?? this.keepNotificationAfterAlarmEnds,
     );
   }
 
   @override
-  List<Object?> get props => [title, body, stopButton, icon];
+  List<Object?> get props =>
+      [title, body, stopButton, icon, keepNotificationAfterAlarmEnds];
 }

--- a/lib/model/notification_settings.g.dart
+++ b/lib/model/notification_settings.g.dart
@@ -17,6 +17,8 @@ NotificationSettings _$NotificationSettingsFromJson(
           body: $checkedConvert('body', (v) => v as String),
           stopButton: $checkedConvert('stopButton', (v) => v as String?),
           icon: $checkedConvert('icon', (v) => v as String?),
+          keepNotificationAfterAlarmEnds: $checkedConvert(
+              'keepNotificationAfterAlarmEnds', (v) => v as bool? ?? false),
         );
         return val;
       },
@@ -29,4 +31,5 @@ Map<String, dynamic> _$NotificationSettingsToJson(
       'body': instance.body,
       if (instance.stopButton case final value?) 'stopButton': value,
       if (instance.icon case final value?) 'icon': value,
+      'keepNotificationAfterAlarmEnds': instance.keepNotificationAfterAlarmEnds,
     };

--- a/lib/src/generated/platform_bindings.g.dart
+++ b/lib/src/generated/platform_bindings.g.dart
@@ -185,6 +185,7 @@ class NotificationSettingsWire {
     required this.body,
     this.stopButton,
     this.icon,
+    required this.keepNotificationAfterAlarmEnds,
   });
 
   String title;
@@ -195,12 +196,15 @@ class NotificationSettingsWire {
 
   String? icon;
 
+  bool keepNotificationAfterAlarmEnds;
+
   Object encode() {
     return <Object?>[
       title,
       body,
       stopButton,
       icon,
+      keepNotificationAfterAlarmEnds,
     ];
   }
 
@@ -211,6 +215,7 @@ class NotificationSettingsWire {
       body: result[1]! as String,
       stopButton: result[2] as String?,
       icon: result[3] as String?,
+      keepNotificationAfterAlarmEnds: result[4]! as bool,
     );
   }
 }

--- a/pigeons/alarm_api.dart
+++ b/pigeons/alarm_api.dart
@@ -73,12 +73,14 @@ class NotificationSettingsWire {
     required this.body,
     required this.stopButton,
     required this.icon,
+    required this.keepNotificationAfterAlarmEnds,
   });
 
   final String title;
   final String body;
   final String? stopButton;
   final String? icon;
+  final bool keepNotificationAfterAlarmEnds;
 }
 
 /// Errors that can occur when interacting with the Alarm API.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   equatable: ^2.0.7
   flutter:
     sdk: flutter
-  flutter_fgbg: ^0.6.0
+  flutter_fgbg: ^0.7.1
   json_annotation: ^4.9.0
   logging: ^1.3.0
   plugin_platform_interface: ^2.1.8


### PR DESCRIPTION
# Add iOS notification persistence option

## Description
Adds the ability to control whether notifications persist after an alarm ends on iOS devices. This feature allows users to maintain alarm notifications in the notification center even after the alarm sound ends.

Implements the feature requested in [#328](https://github.com/gdelataillade/alarm/issues/328)

## Changes
- Added `keepNotificationAfterAlarmEnds` property to `NotificationSettings` model
- Added corresponding field to `NotificationSettingsWire` in Pigeon API
- Generated updated platform bindings

## Example Usage
```dart
NotificationSettings(
  title: 'Wake Up',
  body: 'Time to start your day',
  keepNotificationAfterAlarmEnds: true, // Notification will remain in iOS notification center
);
```

## Technical Details
- iOS-specific feature (no effect on Android)
- Default value is `false` to maintain backward compatibility
- Property is serialized through platform channel communication

## Testing
- [x] Test notification persistence on iOS when `keepNotificationAfterAlarmEnds` is true
- [x] Verify no impact on Android devices
- [x] Verify backward compatibility with existing alarm configurations

## Documentation
Added comprehensive documentation with:
- Clear iOS-only feature indication
- Default value specification
- Behavior description for both true/false states

## Breaking Changes
None. This is a backward-compatible feature addition.