### PR TITLE
Fix self in concurrently-executing code

### DIFF
--- a/ios/Classes/services/AlarmManager.swift
+++ b/ios/Classes/services/AlarmManager.swift
@@ -174,7 +174,7 @@ class AlarmManager: NSObject {
             volumeSettings: config.settings.volumeSettings,
             onComplete: config.settings.loopAudio ? { [weak self] in
                 Task {
-                    await self?.stopAlarm(id: id, cancelNotif: false)
+                    [self] in await self?.stopAlarm(id: id, cancelNotif: false)
                 }
             } : nil)
 


### PR DESCRIPTION
This PR fixes Swift Compiler Error (Xcode): 
Reference to captured var 'self' in concurrently-executing code

I don't know what the exact issue is, and maybe there is a better solution. Without this fix, the app will not build ios. 

[Similar issue](https://forums.swift.org/t/how-is-this-a-reference-to-a-var-in-concurrently-executing-code/66299/2) with discussions.