### PR TITLE
Fix kotlin color after replacing flutter's Color deprecated properties

### DIFF
--- a/android/src/main/kotlin/com/gdelataillade/alarm/models/NotificationSettings.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/models/NotificationSettings.kt
@@ -14,10 +14,10 @@ data class NotificationSettings(
 ) {
     companion object {
         fun fromWire(e: NotificationSettingsWire): NotificationSettings {
-            val a = (e.iconColorAlpha as? String)?.toIntOrNull()
-            val r = (e.iconColorRed as? String)?.toIntOrNull()
-            val g = (e.iconColorGreen as? String)?.toIntOrNull()
-            val b = (e.iconColorBlue as? String)?.toIntOrNull()
+            val a = (e.iconColorAlpha as? String)?.toFloatOrNull()
+            val r = (e.iconColorRed as? String)?.toFloatOrNull()
+            val g = (e.iconColorGreen as? String)?.toFloatOrNull()
+            val b = (e.iconColorBlue as? String)?.toFloatOrNull()
 
             var iconColor: Int? = null
             if (a != null && r != null && g != null && b != null) {


### PR DESCRIPTION
Flutter Color has deprecated properties `alpha`, `red`, `green`, `blue` and suggests using `a`, `r`, `g`, `b`.

However, `a`, `r`, `g`, `b` return floating-point values (between 0.0 and 1.0) while the deprecated properties returned integers between 0 and 255.

So, after you replaced the deprecated properties, the strings passed through `NotificationSettingsWire` represent floats and in `NotificationSettings.kt` you need to convert them to float now (and not integer).

Kotlin's Color argb() method can get 4 floats as it could also get 4 integers so no other change is needed.

I am sorry for not having replaced the deprecated properties in the initial PR, my fault.