### PR TITLE
Icon color components as doubles through pigeon

### DIFF
--- a/android/src/main/kotlin/com/gdelataillade/alarm/generated/FlutterBindings.g.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/generated/FlutterBindings.g.kt
@@ -175,10 +175,10 @@ data class NotificationSettingsWire (
   val body: String,
   val stopButton: String? = null,
   val icon: String? = null,
-  val iconColorAlpha: String? = null,
-  val iconColorRed: String? = null,
-  val iconColorGreen: String? = null,
-  val iconColorBlue: String? = null
+  val iconColorAlpha: Double? = null,
+  val iconColorRed: Double? = null,
+  val iconColorGreen: Double? = null,
+  val iconColorBlue: Double? = null
 )
  {
   companion object {
@@ -187,10 +187,10 @@ data class NotificationSettingsWire (
       val body = pigeonVar_list[1] as String
       val stopButton = pigeonVar_list[2] as String?
       val icon = pigeonVar_list[3] as String?
-      val iconColorAlpha = pigeonVar_list[4] as String?
-      val iconColorRed = pigeonVar_list[5] as String?
-      val iconColorGreen = pigeonVar_list[6] as String?
-      val iconColorBlue = pigeonVar_list[7] as String?
+      val iconColorAlpha = pigeonVar_list[4] as Double?
+      val iconColorRed = pigeonVar_list[5] as Double?
+      val iconColorGreen = pigeonVar_list[6] as Double?
+      val iconColorBlue = pigeonVar_list[7] as Double?
       return NotificationSettingsWire(title, body, stopButton, icon, iconColorAlpha, iconColorRed, iconColorGreen, iconColorBlue)
     }
   }

--- a/android/src/main/kotlin/com/gdelataillade/alarm/models/NotificationSettings.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/models/NotificationSettings.kt
@@ -14,10 +14,10 @@ data class NotificationSettings(
 ) {
     companion object {
         fun fromWire(e: NotificationSettingsWire): NotificationSettings {
-            val a = (e.iconColorAlpha as? String)?.toFloatOrNull()
-            val r = (e.iconColorRed as? String)?.toFloatOrNull()
-            val g = (e.iconColorGreen as? String)?.toFloatOrNull()
-            val b = (e.iconColorBlue as? String)?.toFloatOrNull()
+            val a = e.iconColorAlpha?.toFloat()
+            val r = e.iconColorRed?.toFloat()
+            val g = e.iconColorGreen?.toFloat()
+            val b = e.iconColorBlue?.toFloat()
 
             var iconColor: Int? = null
             if (a != null && r != null && g != null && b != null) {

--- a/ios/Classes/generated/FlutterBindings.g.swift
+++ b/ios/Classes/generated/FlutterBindings.g.swift
@@ -206,10 +206,10 @@ struct NotificationSettingsWire {
   var body: String
   var stopButton: String? = nil
   var icon: String? = nil
-  var iconColorAlpha: String? = nil
-  var iconColorRed: String? = nil
-  var iconColorGreen: String? = nil
-  var iconColorBlue: String? = nil
+  var iconColorAlpha: Double? = nil
+  var iconColorRed: Double? = nil
+  var iconColorGreen: Double? = nil
+  var iconColorBlue: Double? = nil
 
 
   // swift-format-ignore: AlwaysUseLowerCamelCase
@@ -218,10 +218,10 @@ struct NotificationSettingsWire {
     let body = pigeonVar_list[1] as! String
     let stopButton: String? = nilOrValue(pigeonVar_list[2])
     let icon: String? = nilOrValue(pigeonVar_list[3])
-    let iconColorAlpha: String? = nilOrValue(pigeonVar_list[4])
-    let iconColorRed: String? = nilOrValue(pigeonVar_list[5])
-    let iconColorGreen: String? = nilOrValue(pigeonVar_list[6])
-    let iconColorBlue: String? = nilOrValue(pigeonVar_list[7])
+    let iconColorAlpha: Double? = nilOrValue(pigeonVar_list[4])
+    let iconColorRed: Double? = nilOrValue(pigeonVar_list[5])
+    let iconColorGreen: Double? = nilOrValue(pigeonVar_list[6])
+    let iconColorBlue: Double? = nilOrValue(pigeonVar_list[7])
 
     return NotificationSettingsWire(
       title: title,

--- a/lib/model/notification_settings.dart
+++ b/lib/model/notification_settings.dart
@@ -79,10 +79,10 @@ class NotificationSettings extends Equatable {
         body: body,
         stopButton: stopButton,
         icon: icon,
-        iconColorAlpha: iconColor?.a.toString(),
-        iconColorRed: iconColor?.r.toString(),
-        iconColorGreen: iconColor?.g.toString(),
-        iconColorBlue: iconColor?.b.toString(),
+        iconColorAlpha: iconColor?.a,
+        iconColorRed: iconColor?.r,
+        iconColorGreen: iconColor?.g,
+        iconColorBlue: iconColor?.b,
       );
 
   /// Creates a copy of this notification settings but with the given fields

--- a/lib/src/generated/platform_bindings.g.dart
+++ b/lib/src/generated/platform_bindings.g.dart
@@ -288,13 +288,13 @@ class NotificationSettingsWire {
 
   String? icon;
 
-  String? iconColorAlpha;
+  double? iconColorAlpha;
 
-  String? iconColorRed;
+  double? iconColorRed;
 
-  String? iconColorGreen;
+  double? iconColorGreen;
 
-  String? iconColorBlue;
+  double? iconColorBlue;
 
   List<Object?> _toList() {
     return <Object?>[
@@ -320,10 +320,10 @@ class NotificationSettingsWire {
       body: result[1]! as String,
       stopButton: result[2] as String?,
       icon: result[3] as String?,
-      iconColorAlpha: result[4] as String?,
-      iconColorRed: result[5] as String?,
-      iconColorGreen: result[6] as String?,
-      iconColorBlue: result[7] as String?,
+      iconColorAlpha: result[4] as double?,
+      iconColorRed: result[5] as double?,
+      iconColorGreen: result[6] as double?,
+      iconColorBlue: result[7] as double?,
     );
   }
 

--- a/pigeons/alarm_api.dart
+++ b/pigeons/alarm_api.dart
@@ -83,10 +83,10 @@ class NotificationSettingsWire {
   final String body;
   final String? stopButton;
   final String? icon;
-  final String? iconColorAlpha;
-  final String? iconColorRed;
-  final String? iconColorGreen;
-  final String? iconColorBlue;
+  final double? iconColorAlpha;
+  final double? iconColorRed;
+  final double? iconColorGreen;
+  final double? iconColorBlue;
 }
 
 /// Errors that can occur when interacting with the Alarm API.


### PR DESCRIPTION
As @orkun1675 pointed out, it's a better decision to pass the color components as doubles through pigeon.

In Kotlin, we still need to convert them from `Double` to `Float` for passing them to `Color.argb()` method.