### PR TITLE
Fix iOS vibration bug when loopAudio is false

### DIFF
--- a/ios/Classes/services/AlarmManager.swift
+++ b/ios/Classes/services/AlarmManager.swift
@@ -172,7 +172,7 @@ class AlarmManager: NSObject {
             assetAudioPath: config.settings.assetAudioPath,
             loopAudio: config.settings.loopAudio,
             volumeSettings: config.settings.volumeSettings,
-            onComplete: config.settings.loopAudio ? { [weak self] in
+            onComplete: !config.settings.loopAudio ? { [weak self] in
                 Task {
                     [self] in await self?.stopAlarm(id: id, cancelNotif: false)
                 }


### PR DESCRIPTION
## Problem
There was a bug on iOS where vibrations would not stop when audio ended when `loopAudio: false`.

## Root Cause
The condition for the `onComplete` callback was inverted:
- Current: `config.settings.loopAudio ? { ... } : nil`
- Correct: `!config.settings.loopAudio ? { ... } : nil`

## Fix
- Fixed the `onComplete` callback to be set correctly when `loopAudio: false`
- Now `stopAlarm` is called when audio ends, which also stops vibrations

## Behavior
- **Android**: Already working correctly (no changes needed)
- **iOS**: After this fix, vibrations will stop when audio ends

## Documentation Consistency
This fix ensures that the documented behavior "If [loopAudio] is set to false, vibrations will stop when audio ends." matches the actual implementation.

## Testing
The fix has been tested to ensure that:
1. When `loopAudio: false`, audio plays once and stops
2. Vibrations stop automatically when audio ends
3. When `loopAudio: true`, audio loops and vibrations continue until manually stopped

## Files Changed
- `ios/Classes/services/AlarmManager.swift`: Fixed the `onComplete` callback condition