### PR TITLE
Fix Alarm.ringing stream not firing on Android 

### DIFF
--- a/lib/alarm.dart
+++ b/lib/alarm.dart
@@ -104,8 +104,8 @@ class Alarm {
     await AlarmStorage.saveAlarm(alarmSettings);
 
     final success = iOS
-        ? await IOSAlarm.setAlarm(alarmSettings)
-        : await AndroidAlarm.set(alarmSettings);
+        ? await IOSAlarm().setAlarm(alarmSettings)
+        : await AndroidAlarm().setAlarm(alarmSettings);
 
     if (success) {
       _scheduled.add(_scheduled.value.add(alarmSettings));
@@ -155,8 +155,8 @@ class Alarm {
     String title,
     String body,
   ) async {
-    if (iOS) await IOSAlarm.setWarningNotificationOnKill(title, body);
-    if (android) await AndroidAlarm.setWarningNotificationOnKill(title, body);
+    if (iOS) await IOSAlarm().setWarningNotificationOnKill(title, body);
+    if (android) await AndroidAlarm().setWarningNotificationOnKill(title, body);
   }
 
   /// Stops alarm.
@@ -164,8 +164,9 @@ class Alarm {
     await AlarmStorage.unsaveAlarm(id);
     updateStream.add(id);
 
-    final success =
-        iOS ? await IOSAlarm.stopAlarm(id) : await AndroidAlarm.stop(id);
+    final success = iOS
+        ? await IOSAlarm().stopAlarm(id)
+        : await AndroidAlarm().stopAlarm(id);
 
     if (success) {
       _scheduled.add(_scheduled.value.removeById(id));
@@ -179,7 +180,7 @@ class Alarm {
   static Future<void> stopAll() async {
     final alarms = await getAlarms();
 
-    iOS ? await IOSAlarm.stopAll() : await AndroidAlarm.stopAll();
+    iOS ? await IOSAlarm().stopAll() : await AndroidAlarm().stopAll();
 
     await AlarmStorage.unsaveAll();
 
@@ -197,8 +198,9 @@ class Alarm {
   /// If an `id` is provided, it checks if the specific alarm with that `id`
   /// is ringing.
   static Future<bool> isRinging([int? id]) async {
-    final isRinging =
-        iOS ? await IOSAlarm.isRinging(id) : await AndroidAlarm.isRinging(id);
+    final isRinging = iOS
+        ? await IOSAlarm().isRinging(id)
+        : await AndroidAlarm().isRinging(id);
 
     // Defensive programming: check if the stream status matches the platform
     // reported status.

--- a/lib/src/android_alarm.dart
+++ b/lib/src/android_alarm.dart
@@ -1,83 +1,16 @@
-import 'dart:async';
-
-import 'package:alarm/alarm.dart';
-import 'package:alarm/src/generated/platform_bindings.g.dart';
-import 'package:alarm/utils/alarm_exception.dart';
+import 'package:alarm/src/base_alarm.dart';
 import 'package:alarm/utils/alarm_handler.dart';
 import 'package:logging/logging.dart';
-import 'package:alarm/src/platform_timers.dart';
 
-/// Uses method channel to interact with the native platform.
-class AndroidAlarm {
-  static final _log = Logger('AndroidAlarm');
+/// Uses method channel to interact with the native platform for Android.
+class AndroidAlarm extends BaseAlarm {
+  /// Creates an [AndroidAlarm] instance.
+  AndroidAlarm() : super(Logger('AndroidAlarm'));
 
-  static final AlarmApi _api = AlarmApi();
-
-  /// Schedules a native alarm with given [settings] with its notification.
-  static Future<bool> set(AlarmSettings settings) async {
-    final id = settings.id;
-    try {
-      await _api.setAlarm(alarmSettings: settings.toWire()).catchError(AlarmExceptionHandlers.catchError<void>);
-
-      _log.info(
-        'Alarm with id $id scheduled successfully at ${settings.dateTime}',
-      );
-    } on AlarmException catch (_) {
-      await Alarm.stop(id);
-      rethrow;
-    }
-
-    PlatformTimers.setAlarm(settings);
-
-    return true;
-  }
-
-  /// Sends the message `stop` to the isolate so the audio player
-  /// can stop playing and dispose.
-  static Future<bool> stop(int id) async {
-    PlatformTimers.stopAlarm(id);
-
-    try {
-      await _api
-          .stopAlarm(alarmId: id)
-          .catchError(AlarmExceptionHandlers.catchError<void>);
-      return true;
-    } on AlarmException catch (e) {
-      _log.severe('Failed to stop alarm: $e');
-      return false;
-    }
-  }
-
-  /// Calls the native `stopAll` function.
-  static Future<void> stopAll() async {
-    PlatformTimers.stopAll();
-    return _api.stopAll().catchError(AlarmExceptionHandlers.catchError<void>);
-  }
-
-  /// Checks whether an alarm or any alarm (if id is null) is ringing.
-  static Future<bool> isRinging([int? id]) async {
-    try {
-      final res = await _api
-          .isRinging(alarmId: id)
-          .catchError(AlarmExceptionHandlers.catchError<bool>);
-      return res;
-    } on AlarmException catch (e) {
-      _log.severe('Failed to check if alarm is ringing: $e');
-      return false;
-    }
-  }
-
-  /// Sets the native notification on app kill title and body.
-  static Future<void> setWarningNotificationOnKill(String title, String body) =>
-      _api
-          .setWarningNotificationOnKill(
-            title: title,
-            body: body,
-          )
-          .catchError(AlarmExceptionHandlers.catchError<void>);
-
-  /// Disable the notification on kill service.
-  static Future<void> disableWarningNotificationOnKill() => _api
+  /// Disable the notification on kill service (Android-only).
+  Future<void> disableWarningNotificationOnKill() => BaseAlarm.api
       .disableWarningNotificationOnKill()
       .catchError(AlarmExceptionHandlers.catchError<void>);
+
+// Insert other Android platform specific code..
 }

--- a/lib/src/base_alarm.dart
+++ b/lib/src/base_alarm.dart
@@ -1,0 +1,89 @@
+import 'dart:async';
+
+import 'package:alarm/alarm.dart';
+import 'package:alarm/src/generated/platform_bindings.g.dart';
+import 'package:alarm/src/platform_timers.dart';
+import 'package:alarm/utils/alarm_exception.dart';
+import 'package:alarm/utils/alarm_handler.dart';
+import 'package:logging/logging.dart';
+
+/// Abstract base class for platform-specific alarm interactions.
+/// Contains common logic shared between iOS and Android.
+abstract class BaseAlarm {
+  /// Creates a [BaseAlarm] instance with the provided logger.
+  BaseAlarm(this._log);
+
+  /// The shared API instance for alarm operations.
+  static final AlarmApi api = AlarmApi();
+
+  final Logger _log;
+
+  /// Schedules a native alarm with given [settings] with its notification.
+  ///
+  /// Also sets periodic timer and listens for app state changes to trigger
+  /// the alarm ring callback at the right time.
+  Future<bool> setAlarm(AlarmSettings settings) async {
+    final id = settings.id;
+    try {
+      await api
+          .setAlarm(alarmSettings: settings.toWire())
+          .catchError(AlarmExceptionHandlers.catchError<void>);
+
+      _log.info(
+        'Alarm with id $id scheduled successfully at ${settings.dateTime}',
+      );
+    } on AlarmException catch (_) {
+      await Alarm.stop(id);
+      rethrow;
+    }
+
+    PlatformTimers.setAlarm(settings);
+
+    return true;
+  }
+
+  /// Stops the alarm with the given [id].
+  Future<bool> stopAlarm(int id) async {
+    PlatformTimers.stopAlarm(id);
+
+    try {
+      await api
+          .stopAlarm(alarmId: id)
+          .catchError(AlarmExceptionHandlers.catchError<void>);
+
+      _log.info('Alarm with id $id stopped.');
+
+      return true;
+    } on AlarmException catch (e) {
+      _log.severe('Failed to stop alarm $id. $e');
+      return false;
+    }
+  }
+
+  /// Stops all alarms.
+  Future<void> stopAll() async {
+    PlatformTimers.stopAll();
+    return api.stopAll().catchError(AlarmExceptionHandlers.catchError<void>);
+  }
+
+  /// Checks whether an alarm or any alarm (if id is null) is ringing.
+  Future<bool> isRinging([int? id]) async {
+    try {
+      final res = await api
+          .isRinging(alarmId: id)
+          .catchError(AlarmExceptionHandlers.catchError<bool>);
+      return res;
+    } on AlarmException catch (e) {
+      _log.severe('Failed to check if alarm is ringing: $e');
+      return false;
+    }
+  }
+
+  /// Sets the native notification on app kill title and body.
+  Future<void> setWarningNotificationOnKill(String title, String body) => api
+      .setWarningNotificationOnKill(
+        title: title,
+        body: body,
+      )
+      .catchError(AlarmExceptionHandlers.catchError<void>);
+}

--- a/lib/src/ios_alarm.dart
+++ b/lib/src/ios_alarm.dart
@@ -1,79 +1,10 @@
-import 'dart:async';
-
-import 'package:alarm/alarm.dart';
-import 'package:alarm/src/generated/platform_bindings.g.dart';
-import 'package:alarm/src/platform_timers.dart';
-import 'package:alarm/utils/alarm_exception.dart';
-import 'package:alarm/utils/alarm_handler.dart';
+import 'package:alarm/src/base_alarm.dart';
 import 'package:logging/logging.dart';
 
-/// Uses method channel to interact with the native platform.
-class IOSAlarm {
-  static final _log = Logger('IOSAlarm');
+/// Uses method channel to interact with the native platform for iOS.
+class IOSAlarm extends BaseAlarm {
+  /// Creates an [IOSAlarm] instance.
+  IOSAlarm() : super(Logger('IOSAlarm'));
 
-  static final AlarmApi _api = AlarmApi();
-
-  /// Calls the native function `setAlarm` and listens to alarm ring state.
-  ///
-  /// Also set periodic timer and listens for app state changes to trigger
-  /// the alarm ring callback at the right time.
-  static Future<bool> setAlarm(AlarmSettings settings) async {
-    final id = settings.id;
-    try {
-      await _api
-          .setAlarm(alarmSettings: settings.toWire())
-          .catchError(AlarmExceptionHandlers.catchError<void>);
-      _log.info(
-        'Alarm with id $id scheduled successfully at ${settings.dateTime}',
-      );
-    } on AlarmException catch (_) {
-      await Alarm.stop(id);
-      rethrow;
-    }
-
-    PlatformTimers.setAlarm(settings);
-
-    return true;
-  }
-
-  /// and calls the native `stopAlarm` function.
-  static Future<bool> stopAlarm(int id) async {
-    PlatformTimers.stopAlarm(id);
-
-    try {
-      await _api
-          .stopAlarm(alarmId: id)
-          .catchError(AlarmExceptionHandlers.catchError<void>);
-      _log.info('Alarm with id $id stopped.');
-      return true;
-    } on AlarmException catch (e) {
-      _log.severe('Failed to stop alarm $id. $e');
-      return false;
-    }
-  }
-
-  /// Calls the native `stopAll` function.
-  static Future<void> stopAll() async {
-    PlatformTimers.stopAll();
-    return _api.stopAll().catchError(AlarmExceptionHandlers.catchError<void>);
-  }
-
-  /// Checks whether an alarm or any alarm (if id is null) is ringing.
-  static Future<bool> isRinging([int? id]) async {
-    try {
-      final res = await _api
-          .isRinging(alarmId: id)
-          .catchError(AlarmExceptionHandlers.catchError<bool>);
-      return res;
-    } on AlarmException catch (e) {
-      _log.severe('Error checking if alarm is ringing: $e');
-      return false;
-    }
-  }
-
-  /// Sets the native notification on app kill title and body.
-  static Future<void> setWarningNotificationOnKill(String title, String body) =>
-      _api
-          .setWarningNotificationOnKill(title: title, body: body)
-          .catchError(AlarmExceptionHandlers.catchError<void>);
+// insert other IOS platform specific code..
 }

--- a/lib/src/platform_timers.dart
+++ b/lib/src/platform_timers.dart
@@ -27,7 +27,7 @@ class PlatformTimers {
     }
 
     _timers[id] = _periodicTimer(
-          () => unawaited(_alarmRang(settings)),
+      () => unawaited(_alarmRang(settings)),
       settings.dateTime,
       id,
     );
@@ -40,9 +40,9 @@ class PlatformTimers {
 
         bool alarmIsRinging;
         if (Platform.isIOS) {
-          alarmIsRinging = await IOSAlarm.isRinging(id);
+          alarmIsRinging = await IOSAlarm().isRinging(id);
         } else if (Platform.isAndroid) {
-          alarmIsRinging = await AndroidAlarm.isRinging(id);
+          alarmIsRinging = await AndroidAlarm().isRinging(id);
         } else {
           // Fallback for other platforms (though unlikely in this package)
           alarmIsRinging = false;
@@ -57,7 +57,7 @@ class PlatformTimers {
             timer.cancel();
           }
           _timers[id] = _periodicTimer(
-                () => unawaited(_alarmRang(settings)),
+            () => unawaited(_alarmRang(settings)),
             settings.dateTime,
             id,
           );


### PR DESCRIPTION
- Added `platform_timers.dart` to unify iOS and Android backup timer logic, reducing code duplication.
- Removed `ios_timers.dart` as it’s replaced by `platform_timers.dart`.
- Fixed issue where `Alarm.ringing` stream fails to emit on Android, ensuring reliable navigation to the ring screen.
- **Follow-up**: Refactored `ios_alarm.dart` and `android_alarm.dart` into `BaseAlarm` with subclasses to reduce duplication, per orkun1675's suggestion.
- Updated `platform_timers.dart` and `alarm.dart` to use instance methods for `IOSAlarm` and `AndroidAlarm`.
- Tested on Android emulator/device and iOS simulator with alarms in foreground and background.

Closes #380 (references https://github.com/gdelataillade/alarm/issues/380#issuecomment-3256844728)