### PR TITLE
feat: keep notification after alarm ends (Fixes #328)

### DIFF
--- a/android/src/main/kotlin/com/gdelataillade/alarm/generated/FlutterBindings.g.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/generated/FlutterBindings.g.kt
@@ -109,10 +109,6 @@ enum class AlarmErrorCode(val raw: Int) {
 data class AlarmSettingsWire (
   val id: Long,
   val millisecondsSinceEpoch: Long,
-  /**
-   * Path to the audio asset. If null, the device's default alarm sound
-   * will be used (Android only for now).
-   */
   val assetAudioPath: String? = null,
   val volumeSettings: VolumeSettingsWire,
   val notificationSettings: NotificationSettingsWire,
@@ -247,7 +243,8 @@ data class NotificationSettingsWire (
   val iconColorAlpha: Double? = null,
   val iconColorRed: Double? = null,
   val iconColorGreen: Double? = null,
-  val iconColorBlue: Double? = null
+  val iconColorBlue: Double? = null,
+  val keepNotificationAfterAlarmEnds: Boolean
 )
  {
   companion object {
@@ -260,7 +257,8 @@ data class NotificationSettingsWire (
       val iconColorRed = pigeonVar_list[5] as Double?
       val iconColorGreen = pigeonVar_list[6] as Double?
       val iconColorBlue = pigeonVar_list[7] as Double?
-      return NotificationSettingsWire(title, body, stopButton, icon, iconColorAlpha, iconColorRed, iconColorGreen, iconColorBlue)
+      val keepNotificationAfterAlarmEnds = pigeonVar_list[8] as Boolean
+      return NotificationSettingsWire(title, body, stopButton, icon, iconColorAlpha, iconColorRed, iconColorGreen, iconColorBlue, keepNotificationAfterAlarmEnds)
     }
   }
   fun toList(): List<Any?> {
@@ -273,6 +271,7 @@ data class NotificationSettingsWire (
       iconColorRed,
       iconColorGreen,
       iconColorBlue,
+      keepNotificationAfterAlarmEnds,
     )
   }
   override fun equals(other: Any?): Boolean {

--- a/android/src/main/kotlin/com/gdelataillade/alarm/models/NotificationSettings.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/models/NotificationSettings.kt
@@ -10,7 +10,8 @@ data class NotificationSettings(
     val body: String,
     val stopButton: String? = null,
     val icon: String? = null,
-    val iconColor: Int? = null
+    val iconColor: Int? = null,
+    val keepNotificationAfterAlarmEnds: Boolean = false,
 ) {
     companion object {
         fun fromWire(e: NotificationSettingsWire): NotificationSettings {
@@ -30,6 +31,7 @@ data class NotificationSettings(
                 e.stopButton,
                 e.icon,
                 iconColor,
+                e.keepNotificationAfterAlarmEnds,
             )
         }
     }

--- a/ios/Classes/generated/FlutterBindings.g.swift
+++ b/ios/Classes/generated/FlutterBindings.g.swift
@@ -152,8 +152,6 @@ enum AlarmErrorCode: Int {
 struct AlarmSettingsWire: Hashable {
   var id: Int64
   var millisecondsSinceEpoch: Int64
-  /// Path to the audio asset. If null, the device's default alarm sound
-  /// will be used (Android only for now).
   var assetAudioPath: String? = nil
   var volumeSettings: VolumeSettingsWire
   var notificationSettings: NotificationSettingsWire
@@ -295,6 +293,7 @@ struct NotificationSettingsWire: Hashable {
   var iconColorRed: Double? = nil
   var iconColorGreen: Double? = nil
   var iconColorBlue: Double? = nil
+  var keepNotificationAfterAlarmEnds: Bool
 
 
   // swift-format-ignore: AlwaysUseLowerCamelCase
@@ -307,6 +306,7 @@ struct NotificationSettingsWire: Hashable {
     let iconColorRed: Double? = nilOrValue(pigeonVar_list[5])
     let iconColorGreen: Double? = nilOrValue(pigeonVar_list[6])
     let iconColorBlue: Double? = nilOrValue(pigeonVar_list[7])
+    let keepNotificationAfterAlarmEnds = pigeonVar_list[8] as! Bool
 
     return NotificationSettingsWire(
       title: title,
@@ -316,7 +316,8 @@ struct NotificationSettingsWire: Hashable {
       iconColorAlpha: iconColorAlpha,
       iconColorRed: iconColorRed,
       iconColorGreen: iconColorGreen,
-      iconColorBlue: iconColorBlue
+      iconColorBlue: iconColorBlue,
+      keepNotificationAfterAlarmEnds: keepNotificationAfterAlarmEnds
     )
   }
   func toList() -> [Any?] {
@@ -329,6 +330,7 @@ struct NotificationSettingsWire: Hashable {
       iconColorRed,
       iconColorGreen,
       iconColorBlue,
+      keepNotificationAfterAlarmEnds,
     ]
   }
   static func == (lhs: NotificationSettingsWire, rhs: NotificationSettingsWire) -> Bool {

--- a/ios/Classes/models/NotificationSettings.swift
+++ b/ios/Classes/models/NotificationSettings.swift
@@ -4,6 +4,7 @@ struct NotificationSettings: Codable {
     var title: String
     var body: String
     var stopButton: String?
+    var keepNotificationAfterAlarmEnds: Bool
 
     static func from(wire: NotificationSettingsWire) -> NotificationSettings {
         // NotificationSettingsWire.icon and iconColor values are ignored
@@ -11,7 +12,8 @@ struct NotificationSettings: Codable {
         return NotificationSettings(
             title: wire.title,
             body: wire.body,
-            stopButton: wire.stopButton
+            stopButton: wire.stopButton,
+            keepNotificationAfterAlarmEnds: wire.keepNotificationAfterAlarmEnds
         )
     }
 
@@ -19,7 +21,8 @@ struct NotificationSettings: Codable {
         return NotificationSettings(
             title: json["title"] as! String,
             body: json["body"] as! String,
-            stopButton: json["stopButton"] as? String
+            stopButton: json["stopButton"] as? String,
+            keepNotificationAfterAlarmEnds: json["keepNotificationAfterAlarmEnds"] as? Bool ?? false
         )
     }
 
@@ -27,7 +30,8 @@ struct NotificationSettings: Codable {
         return [
             "title": notificationSettings.title,
             "body": notificationSettings.body,
-            "stopButton": notificationSettings.stopButton as Any
+            "stopButton": notificationSettings.stopButton as Any,
+            "keepNotificationAfterAlarmEnds": notificationSettings.keepNotificationAfterAlarmEnds
         ]
     }
 }

--- a/ios/Classes/services/AlarmManager.swift
+++ b/ios/Classes/services/AlarmManager.swift
@@ -51,7 +51,17 @@ class AlarmManager: NSObject {
         if cancelNotif {
             NotificationManager.shared.cancelNotification(id: id)
         }
-        NotificationManager.shared.dismissNotification(id: id)
+
+        // When the alarm stops automatically because the sound finished (non-looping
+        // alarms), we may want to keep the delivered notification so the user can
+        // still see it in the notification center. This is controlled by
+        // `NotificationSettings.keepNotificationAfterAlarmEnds`.
+        let shouldKeepDeliveredNotification =
+            !cancelNotif && (self.alarms[id]?.settings.notificationSettings.keepNotificationAfterAlarmEnds ?? false)
+
+        if !shouldKeepDeliveredNotification {
+            NotificationManager.shared.dismissNotification(id: id)
+        }
 
         await AlarmRingManager.shared.stop()
 

--- a/lib/model/notification_settings.dart
+++ b/lib/model/notification_settings.dart
@@ -18,6 +18,7 @@ class NotificationSettings extends Equatable {
     this.stopButton,
     this.icon,
     this.iconColor,
+    this.keepNotificationAfterAlarmEnds = false,
   });
 
   /// Converts the JSON object to a `NotificationSettings` instance.
@@ -70,6 +71,19 @@ class NotificationSettings extends Equatable {
   /// Defaults to `null`.
   final Color? iconColor;
 
+  /// Keeps the notification banner visible even after the alarm sound ends.
+  ///
+  /// **iOS only for now.** On Android, the notification already stays
+  /// visible after the sound ends because it is tied to the foreground
+  /// service.
+  ///
+  /// If `true`, when the alarm finishes ringing automatically (non-looping
+  /// alarms), the delivered notification will not be dismissed so the user
+  /// can still see it in the notification center.
+  ///
+  /// Defaults to `false`.
+  final bool keepNotificationAfterAlarmEnds;
+
   /// Converts the `NotificationSettings` instance to a JSON object.
   Map<String, dynamic> toJson() => _$NotificationSettingsToJson(this);
 
@@ -83,6 +97,7 @@ class NotificationSettings extends Equatable {
         iconColorRed: iconColor?.r,
         iconColorGreen: iconColor?.g,
         iconColorBlue: iconColor?.b,
+        keepNotificationAfterAlarmEnds: keepNotificationAfterAlarmEnds,
       );
 
   /// Creates a copy of this notification settings but with the given fields
@@ -93,6 +108,7 @@ class NotificationSettings extends Equatable {
     String? stopButton,
     String? icon,
     Color? iconColor,
+    bool? keepNotificationAfterAlarmEnds,
   }) {
     assert(title != null, 'NotificationSettings.title cannot be null');
     assert(body != null, 'NotificationSettings.body cannot be null');
@@ -103,9 +119,18 @@ class NotificationSettings extends Equatable {
       stopButton: stopButton ?? this.stopButton,
       icon: icon ?? this.icon,
       iconColor: iconColor ?? this.iconColor,
+      keepNotificationAfterAlarmEnds:
+          keepNotificationAfterAlarmEnds ?? this.keepNotificationAfterAlarmEnds,
     );
   }
 
   @override
-  List<Object?> get props => [title, body, stopButton, icon, iconColor];
+  List<Object?> get props => [
+        title,
+        body,
+        stopButton,
+        icon,
+        iconColor,
+        keepNotificationAfterAlarmEnds,
+      ];
 }

--- a/lib/model/notification_settings.g.dart
+++ b/lib/model/notification_settings.g.dart
@@ -17,6 +17,15 @@ NotificationSettings _$NotificationSettingsFromJson(
           body: $checkedConvert('body', (v) => v as String),
           stopButton: $checkedConvert('stopButton', (v) => v as String?),
           icon: $checkedConvert('icon', (v) => v as String?),
+          iconColor: $checkedConvert(
+              'iconColor',
+              (v) => v == null
+                  ? null
+                  : Color(
+                      v as int,
+                    )),
+          keepNotificationAfterAlarmEnds: $checkedConvert(
+              'keepNotificationAfterAlarmEnds', (v) => v as bool? ?? false),
         );
         return val;
       },
@@ -29,4 +38,6 @@ Map<String, dynamic> _$NotificationSettingsToJson(
       'body': instance.body,
       if (instance.stopButton case final value?) 'stopButton': value,
       if (instance.icon case final value?) 'icon': value,
+      if (instance.iconColor case final value?) 'iconColor': value.value,
+      'keepNotificationAfterAlarmEnds': instance.keepNotificationAfterAlarmEnds,
     };

--- a/lib/src/generated/platform_bindings.g.dart
+++ b/lib/src/generated/platform_bindings.g.dart
@@ -81,8 +81,6 @@ class AlarmSettingsWire {
 
   int millisecondsSinceEpoch;
 
-  /// Path to the audio asset. If null, the device's default alarm sound
-  /// will be used (Android only for now).
   String? assetAudioPath;
 
   VolumeSettingsWire volumeSettings;
@@ -271,6 +269,7 @@ class NotificationSettingsWire {
     this.iconColorRed,
     this.iconColorGreen,
     this.iconColorBlue,
+    required this.keepNotificationAfterAlarmEnds,
   });
 
   String title;
@@ -289,6 +288,8 @@ class NotificationSettingsWire {
 
   double? iconColorBlue;
 
+  bool keepNotificationAfterAlarmEnds;
+
   List<Object?> _toList() {
     return <Object?>[
       title,
@@ -299,6 +300,7 @@ class NotificationSettingsWire {
       iconColorRed,
       iconColorGreen,
       iconColorBlue,
+      keepNotificationAfterAlarmEnds,
     ];
   }
 
@@ -317,6 +319,7 @@ class NotificationSettingsWire {
       iconColorRed: result[5] as double?,
       iconColorGreen: result[6] as double?,
       iconColorBlue: result[7] as double?,
+      keepNotificationAfterAlarmEnds: result[8]! as bool,
     );
   }
 

--- a/pigeons/alarm_api.dart
+++ b/pigeons/alarm_api.dart
@@ -79,6 +79,7 @@ class NotificationSettingsWire {
     required this.iconColorRed,
     required this.iconColorGreen,
     required this.iconColorBlue,
+    required this.keepNotificationAfterAlarmEnds,
   });
 
   final String title;
@@ -89,6 +90,7 @@ class NotificationSettingsWire {
   final double? iconColorRed;
   final double? iconColorGreen;
   final double? iconColorBlue;
+  final bool keepNotificationAfterAlarmEnds;
 }
 
 /// Errors that can occur when interacting with the Alarm API.


### PR DESCRIPTION
## Description
This PR adds the ability to keep the notification visible after the alarm stops ringing, as requested in issue #328.

## Changes
- Added `keepNotificationAfterAlarmEnds` setting in data models
- Updated Android and iOS bindings to support the new feature
- Modified AlarmManager and notification logic to persist notifications after alarm ends
- Ensured cross-platform compatibility

## Testing
- Tested successfully on Android and iOS devices
- All existing functionality remains intact
- Backward compatible

## Issue reference
Resolves #328