### PR TITLE
feat(android): expose showSystemUI through VolumeSettings so consumers can suppress the volume bar

### DIFF
--- a/android/src/main/kotlin/com/gdelataillade/alarm/alarm/AlarmService.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/alarm/AlarmService.kt
@@ -176,6 +176,7 @@ class AlarmService : Service() {
 
         // Retrieve whether the alarm should be stopped on task termination
         shouldStopAlarmOnTermination = alarmSettings.androidStopAlarmOnTermination
+        showSystemUI = alarmSettings.volumeSettings.showSystemUI
 
         // Acquire a wake lock to wake up the device
         val wakeLock = (getSystemService(Context.POWER_SERVICE) as PowerManager)

--- a/android/src/main/kotlin/com/gdelataillade/alarm/alarm/AlarmService.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/alarm/AlarmService.kt
@@ -136,6 +136,9 @@ class AlarmService : Service() {
             }
         }
 
+        // Read showSystemUI before any volume calls that depend on it
+        showSystemUI = alarmSettings.volumeSettings.showSystemUI
+
         // Set the volume if specified
         if (alarmSettings.volumeSettings.volume != null) {
             volumeService?.setVolume(
@@ -176,7 +179,6 @@ class AlarmService : Service() {
 
         // Retrieve whether the alarm should be stopped on task termination
         shouldStopAlarmOnTermination = alarmSettings.androidStopAlarmOnTermination
-        showSystemUI = alarmSettings.volumeSettings.showSystemUI
 
         // Acquire a wake lock to wake up the device
         val wakeLock = (getSystemService(Context.POWER_SERVICE) as PowerManager)

--- a/android/src/main/kotlin/com/gdelataillade/alarm/generated/FlutterBindings.g.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/generated/FlutterBindings.g.kt
@@ -171,7 +171,8 @@ data class VolumeSettingsWire (
   val volume: Double? = null,
   val fadeDurationMillis: Long? = null,
   val fadeSteps: List<VolumeFadeStepWire>,
-  val volumeEnforced: Boolean
+  val volumeEnforced: Boolean,
+  val showSystemUI: Boolean
 )
  {
   companion object {
@@ -180,7 +181,8 @@ data class VolumeSettingsWire (
       val fadeDurationMillis = pigeonVar_list[1] as Long?
       val fadeSteps = pigeonVar_list[2] as List<VolumeFadeStepWire>
       val volumeEnforced = pigeonVar_list[3] as Boolean
-      return VolumeSettingsWire(volume, fadeDurationMillis, fadeSteps, volumeEnforced)
+      val showSystemUI = pigeonVar_list[4] as Boolean
+      return VolumeSettingsWire(volume, fadeDurationMillis, fadeSteps, volumeEnforced, showSystemUI)
     }
   }
   fun toList(): List<Any?> {
@@ -189,6 +191,7 @@ data class VolumeSettingsWire (
       fadeDurationMillis,
       fadeSteps,
       volumeEnforced,
+      showSystemUI,
     )
   }
   override fun equals(other: Any?): Boolean {

--- a/android/src/main/kotlin/com/gdelataillade/alarm/models/AlarmSettings.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/models/AlarmSettings.kt
@@ -84,7 +84,8 @@ data class AlarmSettings(
                     volume = volume,
                     fadeDuration = fadeDuration?.toKotlinDuration(),
                     fadeSteps = emptyList(), // No equivalent for older models
-                    volumeEnforced = volumeEnforced
+                    volumeEnforced = volumeEnforced,
+                    showSystemUI = true
                 )
             }
 

--- a/android/src/main/kotlin/com/gdelataillade/alarm/models/VolumeSettings.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/models/VolumeSettings.kt
@@ -11,7 +11,8 @@ data class VolumeSettings(
     val volume: Double?,
     val fadeDuration: Duration?,
     val fadeSteps: List<VolumeFadeStep>,
-    val volumeEnforced: Boolean
+    val volumeEnforced: Boolean,
+    val showSystemUI: Boolean
 ) {
     companion object {
         fun fromWire(e: VolumeSettingsWire): VolumeSettings {
@@ -20,6 +21,7 @@ data class VolumeSettings(
                 e.fadeDurationMillis?.milliseconds,
                 e.fadeSteps.map { VolumeFadeStep.fromWire(it) },
                 e.volumeEnforced,
+                e.showSystemUI,
             )
         }
     }

--- a/android/src/main/kotlin/com/gdelataillade/alarm/models/VolumeSettings.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/models/VolumeSettings.kt
@@ -12,7 +12,7 @@ data class VolumeSettings(
     val fadeDuration: Duration?,
     val fadeSteps: List<VolumeFadeStep>,
     val volumeEnforced: Boolean,
-    val showSystemUI: Boolean
+    val showSystemUI: Boolean = true
 ) {
     companion object {
         fun fromWire(e: VolumeSettingsWire): VolumeSettings {

--- a/ios/Classes/generated/FlutterBindings.g.swift
+++ b/ios/Classes/generated/FlutterBindings.g.swift
@@ -223,6 +223,7 @@ struct VolumeSettingsWire: Hashable {
   var fadeDurationMillis: Int64? = nil
   var fadeSteps: [VolumeFadeStepWire]
   var volumeEnforced: Bool
+  var showSystemUI: Bool
 
 
   // swift-format-ignore: AlwaysUseLowerCamelCase
@@ -231,12 +232,14 @@ struct VolumeSettingsWire: Hashable {
     let fadeDurationMillis: Int64? = nilOrValue(pigeonVar_list[1])
     let fadeSteps = pigeonVar_list[2] as! [VolumeFadeStepWire]
     let volumeEnforced = pigeonVar_list[3] as! Bool
+    let showSystemUI = pigeonVar_list[4] as! Bool
 
     return VolumeSettingsWire(
       volume: volume,
       fadeDurationMillis: fadeDurationMillis,
       fadeSteps: fadeSteps,
-      volumeEnforced: volumeEnforced
+      volumeEnforced: volumeEnforced,
+      showSystemUI: showSystemUI
     )
   }
   func toList() -> [Any?] {
@@ -245,6 +248,7 @@ struct VolumeSettingsWire: Hashable {
       fadeDurationMillis,
       fadeSteps,
       volumeEnforced,
+      showSystemUI,
     ]
   }
   static func == (lhs: VolumeSettingsWire, rhs: VolumeSettingsWire) -> Bool {

--- a/lib/model/volume_settings.dart
+++ b/lib/model/volume_settings.dart
@@ -13,6 +13,7 @@ class VolumeSettings extends Equatable {
     this.fadeDuration,
     this.fadeSteps = const [],
     this.volumeEnforced = false,
+    this.showSystemUI = true,
   })  : assert(
           volume == null || (volume >= 0 && volume <= 1),
           'volume must be NULL or in the range [0, 1]',
@@ -26,9 +27,11 @@ class VolumeSettings extends Equatable {
   const VolumeSettings.fixed({
     double? volume,
     bool volumeEnforced = false,
+    bool showSystemUI = true,
   }) : this._(
           volume: volume,
           volumeEnforced: volumeEnforced,
+          showSystemUI: showSystemUI,
         );
 
   /// Constructs [VolumeSettings] with fading volume level.
@@ -36,10 +39,12 @@ class VolumeSettings extends Equatable {
     required Duration fadeDuration,
     double? volume,
     bool volumeEnforced = false,
+    bool showSystemUI = true,
   }) : this._(
           volume: volume,
           fadeDuration: fadeDuration,
           volumeEnforced: volumeEnforced,
+          showSystemUI: showSystemUI,
         );
 
   /// Constructs [VolumeSettings] with slowly increasing (stepped) volume level.
@@ -47,12 +52,14 @@ class VolumeSettings extends Equatable {
     required List<VolumeFadeStep> fadeSteps,
     double? volume,
     bool volumeEnforced = false,
+    bool showSystemUI = true,
   }) {
     assert(fadeSteps.isNotEmpty, 'fadeSteps must not be empty');
     return VolumeSettings._(
       volume: volume,
       fadeSteps: fadeSteps,
       volumeEnforced: volumeEnforced,
+      showSystemUI: showSystemUI,
     );
   }
 
@@ -95,6 +102,12 @@ class VolumeSettings extends Equatable {
   /// Defaults to false.
   final bool volumeEnforced;
 
+  /// If true, the system volume bar is shown when the alarm sets or restores
+  /// the volume. Set to false to suppress the volume UI entirely.
+  ///
+  /// Defaults to true.
+  final bool showSystemUI;
+
   /// Converts the [VolumeSettings] instance to a JSON object.
   Map<String, dynamic> toJson() => _$VolumeSettingsToJson(this);
 
@@ -104,10 +117,12 @@ class VolumeSettings extends Equatable {
         fadeDurationMillis: fadeDuration?.inMilliseconds,
         fadeSteps: fadeSteps.map((e) => e.toWire()).toList(),
         volumeEnforced: volumeEnforced,
+        showSystemUI: showSystemUI,
       );
 
   @override
-  List<Object?> get props => [volume, fadeDuration, fadeSteps, volumeEnforced];
+  List<Object?> get props =>
+      [volume, fadeDuration, fadeSteps, volumeEnforced, showSystemUI];
 }
 
 /// Represents a step in a volume fade sequence.

--- a/lib/model/volume_settings.g.dart
+++ b/lib/model/volume_settings.g.dart
@@ -28,6 +28,8 @@ VolumeSettings _$VolumeSettingsFromJson(Map<String, dynamic> json) =>
                   const []),
           volumeEnforced:
               $checkedConvert('volumeEnforced', (v) => v as bool? ?? false),
+          showSystemUI:
+              $checkedConvert('showSystemUI', (v) => v as bool? ?? true),
         );
         return val;
       },
@@ -40,6 +42,7 @@ Map<String, dynamic> _$VolumeSettingsToJson(VolumeSettings instance) =>
         'fadeDuration': value,
       'fadeSteps': instance.fadeSteps.map((e) => e.toJson()).toList(),
       'volumeEnforced': instance.volumeEnforced,
+      'showSystemUI': instance.showSystemUI,
     };
 
 VolumeFadeStep _$VolumeFadeStepFromJson(Map<String, dynamic> json) =>

--- a/lib/src/generated/platform_bindings.g.dart
+++ b/lib/src/generated/platform_bindings.g.dart
@@ -163,6 +163,7 @@ class VolumeSettingsWire {
     this.fadeDurationMillis,
     required this.fadeSteps,
     required this.volumeEnforced,
+    required this.showSystemUI,
   });
 
   double? volume;
@@ -173,12 +174,15 @@ class VolumeSettingsWire {
 
   bool volumeEnforced;
 
+  bool showSystemUI;
+
   List<Object?> _toList() {
     return <Object?>[
       volume,
       fadeDurationMillis,
       fadeSteps,
       volumeEnforced,
+      showSystemUI,
     ];
   }
 
@@ -193,6 +197,7 @@ class VolumeSettingsWire {
       fadeDurationMillis: result[1] as int?,
       fadeSteps: (result[2] as List<Object?>?)!.cast<VolumeFadeStepWire>(),
       volumeEnforced: result[3]! as bool,
+      showSystemUI: result[4]! as bool,
     );
   }
 

--- a/pigeons/alarm_api.dart
+++ b/pigeons/alarm_api.dart
@@ -51,12 +51,14 @@ class VolumeSettingsWire {
     required this.fadeDurationMillis,
     required this.fadeSteps,
     required this.volumeEnforced,
+    required this.showSystemUI,
   });
 
   final double? volume;
   final int? fadeDurationMillis;
   final List<VolumeFadeStepWire> fadeSteps;
   final bool volumeEnforced;
+  final bool showSystemUI;
 }
 
 class VolumeFadeStepWire {


### PR DESCRIPTION
## Problem

Discovered during review of #396. `AlarmService.kt` hardcodes `showSystemUI = true`,
making it impossible for consumers to prevent the system volume bar from appearing
when the alarm sets or restores volume:

```kotlin
// AlarmService.kt
private var showSystemUI: Boolean = true
```
`VolumeService.setVolume()` already accepted showSystemUI correctly and gated
`FLAG_SHOW_UI` on it — the parameter was simply never reachable from the public API.

## Fix
Threads `showSystemUI` (default `true` for backward compatibility) through the full stack:

* `pigeons/alarm_api.dart` — added to `VolumeSettingsWire`
* `lib/model/volume_settings.dart` — added to `VolumeSettings` and all named constructors (`fixed`, `fade`, `staircaseFade`)
* Regenerated platform bindings (Dart + Kotlin + Swift)
* `VolumeSettings.kt` — added field, read from wire
* `AlarmService.kt` — removed hardcoded `true`, reads from `alarmSettings.volumeSettings.showSystemUI` at alarm start

## Usage

```kotlin
VolumeSettings.fixed(
  volume: 0.8,
  showSystemUI: false, // suppress the volume bar
)
```

Fixes #398.
Tested on: Pixel 9a, Android 16