### PR TITLE
feat: add allowSameSecondScheduling for same-second alarm coexistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,25 @@ You can also listen to the `Alarm.updateStream` to know when an alarm is added, 
 
 To avoid unexpected behaviors, if you set an alarm for the same time, down to the second, as an existing one, the new alarm will replace the existing one.
 
+If you need to schedule multiple alarms with different ids for the exact same second, you can set `allowSameSecondScheduling` to `true`:
+
+```dart
+AlarmSettings(
+  id: 1,
+  dateTime: dateTime,
+  allowSameSecondScheduling: true,
+  // ...
+)
+```
+
+When `allowSameSecondScheduling` is enabled:
+- Alarms with the **same id** still replace each other
+- Alarms with **different ids** can be scheduled for the same second
+- How they ring depends on `allowAlarmOverlap`:
+  - `allowAlarmOverlap = false` (default): Alarms ring **sequentially** one after another — just like the iOS system Clock app. The first alarm rings first; when it stops, the next queued alarm starts ringing automatically.
+  - `allowAlarmOverlap = true`: Alarms ring **concurrently** — the later alarm will override the previous one and continue ringing.
+- These two options are independent and can be combined as needed
+
 ## 📱 Example app
 
 Don't hesitate to check out the [example's code](https://github.com/gdelataillade/alarm/tree/main/example), and take a look at the app:

--- a/android/src/main/kotlin/com/gdelataillade/alarm/alarm/AlarmService.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/alarm/AlarmService.kt
@@ -39,6 +39,8 @@ class AlarmService : Service() {
     private var alarmStorage: AlarmStorage? = null
     private var showSystemUI: Boolean = true
     private var shouldStopAlarmOnTermination: Boolean = true
+    private val ringingQueue = mutableListOf<Int>()
+    private val queuedAlarmSettings = mutableMapOf<Int, AlarmSettings>()
 
     override fun onCreate() {
         super.onCreate()
@@ -92,6 +94,36 @@ class AlarmService : Service() {
             return START_NOT_STICKY
         }
 
+        // If another alarm is already ringing
+        if (ringingAlarmIds.isNotEmpty()) {
+            if (!alarmSettings.allowAlarmOverlap) {
+                // Queue for sequential ringing (like iOS system Clock app)
+                ringingQueue.add(id)
+                queuedAlarmSettings[id] = alarmSettings
+                Log.d(TAG, "Alarm $id queued because another alarm is already ringing.")
+                return START_NOT_STICKY
+            }
+            // allowAlarmOverlap == true: continue to ring, later alarm overrides previous one
+        }
+
+        ringAlarm(id, alarmSettings)
+        return START_STICKY
+    }
+
+    private fun ringAlarm(id: Int, alarmSettings: AlarmSettings) {
+        alarmId = id
+
+        // Build the notification
+        val notificationHandler = NotificationHandler(this)
+        val appIntent =
+            applicationContext.packageManager.getLaunchIntentForPackage(applicationContext.packageName)
+        val pendingIntent = PendingIntent.getActivity(
+            this,
+            id,
+            appIntent,
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+        )
+
         val notification = notificationHandler.buildNotification(
             alarmSettings.notificationSettings,
             alarmSettings.androidFullScreenIntent,
@@ -106,21 +138,14 @@ class AlarmService : Service() {
                     startAlarmService(id, notification)
                 } catch (e: ForegroundServiceStartNotAllowedException) {
                     Log.e(TAG, "Foreground service start not allowed", e)
-                    return START_NOT_STICKY
+                    return
                 }
             } else {
                 startAlarmService(id, notification)
             }
         } catch (e: Exception) {
             Log.e(TAG, "Exception while starting foreground service: ${e.message}", e)
-            return START_NOT_STICKY
-        }
-
-        // Check if an alarm is already ringing
-        if (!alarmSettings.allowAlarmOverlap && ringingAlarmIds.isNotEmpty() && action != "STOP_ALARM") {
-            Log.d(TAG, "An alarm is already ringing. Ignoring new alarm with id: $id")
-            unsaveAlarm(id)
-            return START_NOT_STICKY
+            return
         }
 
         if (alarmSettings.androidFullScreenIntent) {
@@ -153,7 +178,7 @@ class AlarmService : Service() {
         volumeService?.requestAudioFocus(alarmSettings.preferConnectedAudioDevice)
 
         // Set up audio completion listener
-        audioService?.setOnAudioCompleteListener {
+        audioService?.setOnAudioCompleteListener(id) {
             if (!alarmSettings.loopAudio) {
                 vibrationService?.stopVibrating()
                 volumeService?.restorePreviousVolume(showSystemUI)
@@ -200,8 +225,6 @@ class AlarmService : Service() {
                 Log.d(TAG, "Keeping the warning notification on because there are other pending alarms.")
             }
         }
-
-        return START_STICKY
     }
 
     override fun onTaskRemoved(rootIntent: Intent?) {
@@ -249,24 +272,32 @@ class AlarmService : Service() {
     }
 
     private fun stopAlarm(id: Int) {
-        AlarmRingingLiveData.instance.update(false)
         try {
+            audioService?.stopAudio(id)
+
             val playingIds = audioService?.getPlayingMediaPlayersIds() ?: listOf()
             ringingAlarmIds = playingIds
 
-            // Safely call methods on 'volumeService' and 'audioService'
-            volumeService?.restorePreviousVolume(showSystemUI)
-            volumeService?.abandonAudioFocus()
+            if (playingIds.isEmpty()) {
+                // Check if there are queued alarms to trigger next
+                if (ringingQueue.isNotEmpty()) {
+                    val nextId = ringingQueue.removeAt(ringingQueue.lastIndex)
+                    val nextSettings = queuedAlarmSettings.remove(nextId)
+                    nextSettings?.let {
+                        Log.d(TAG, "Triggering queued alarm $nextId.")
+                        ringAlarm(nextId, it)
+                        return
+                    }
+                }
 
-            audioService?.stopAudio(id)
-
-            // Check if media player is empty safely
-            if (audioService?.isMediaPlayerEmpty() == true) {
+                // No more queued alarms, perform full cleanup
+                AlarmRingingLiveData.instance.update(false)
+                volumeService?.restorePreviousVolume(showSystemUI)
+                volumeService?.abandonAudioFocus()
                 vibrationService?.stopVibrating()
+                stopForeground(true)
                 stopSelf()
             }
-
-            stopForeground(true)
         } catch (e: IllegalStateException) {
             Log.e(TAG, "Illegal State: ${e.message}", e)
         } catch (e: Exception) {
@@ -276,6 +307,8 @@ class AlarmService : Service() {
 
     override fun onDestroy() {
         ringingAlarmIds = listOf()
+        ringingQueue.clear()
+        queuedAlarmSettings.clear()
 
         audioService?.cleanUp()
         vibrationService?.stopVibrating()

--- a/android/src/main/kotlin/com/gdelataillade/alarm/alarm/AlarmService.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/alarm/AlarmService.kt
@@ -95,15 +95,18 @@ class AlarmService : Service() {
         }
 
         // If another alarm is already ringing
-        if (ringingAlarmIds.isNotEmpty()) {
-            if (!alarmSettings.allowAlarmOverlap) {
+        if (!alarmSettings.allowAlarmOverlap && ringingAlarmIds.isNotEmpty()) {
+            if (alarmSettings.allowSameSecondScheduling) {
                 // Queue for sequential ringing (like iOS system Clock app)
                 ringingQueue.add(id)
                 queuedAlarmSettings[id] = alarmSettings
                 Log.d(TAG, "Alarm $id queued because another alarm is already ringing.")
                 return START_NOT_STICKY
+            } else {
+                Log.d(TAG, "An alarm is already ringing. Ignoring new alarm with id: $id")
+                unsaveAlarm(id)
+                return START_NOT_STICKY
             }
-            // allowAlarmOverlap == true: continue to ring, later alarm overrides previous one
         }
 
         ringAlarm(id, alarmSettings)
@@ -275,33 +278,48 @@ class AlarmService : Service() {
         try {
             audioService?.stopAudio(id)
 
+            // Remove from queue if present so stopped alarms never get promoted
+            ringingQueue.remove(id)
+            queuedAlarmSettings.remove(id)
+
             val playingIds = audioService?.getPlayingMediaPlayersIds() ?: listOf()
             ringingAlarmIds = playingIds
 
             if (playingIds.isEmpty()) {
-                // Check if there are queued alarms to trigger next
-                if (ringingQueue.isNotEmpty()) {
-                    val nextId = ringingQueue.removeAt(ringingQueue.lastIndex)
-                    val nextSettings = queuedAlarmSettings.remove(nextId)
-                    nextSettings?.let {
-                        Log.d(TAG, "Triggering queued alarm $nextId.")
-                        ringAlarm(nextId, it)
-                        return
-                    }
-                }
+                triggerNextQueuedAlarm()
 
-                // No more queued alarms, perform full cleanup
-                AlarmRingingLiveData.instance.update(false)
-                volumeService?.restorePreviousVolume(showSystemUI)
-                volumeService?.abandonAudioFocus()
-                vibrationService?.stopVibrating()
-                stopForeground(true)
-                stopSelf()
+                if (ringingAlarmIds.isEmpty()) {
+                    // No more queued alarms, perform full cleanup
+                    AlarmRingingLiveData.instance.update(false)
+                    volumeService?.restorePreviousVolume(showSystemUI)
+                    volumeService?.abandonAudioFocus()
+                    vibrationService?.stopVibrating()
+                    stopForeground(true)
+                    stopSelf()
+                }
             }
         } catch (e: IllegalStateException) {
             Log.e(TAG, "Illegal State: ${e.message}", e)
         } catch (e: Exception) {
             Log.e(TAG, "Error in stopping alarm: ${e.message}", e)
+        }
+    }
+
+    private fun triggerNextQueuedAlarm() {
+        while (ringingQueue.isNotEmpty()) {
+            val nextId = ringingQueue.removeAt(ringingQueue.lastIndex)
+            val nextSettings = queuedAlarmSettings.remove(nextId)
+            if (nextSettings != null) {
+                // Validate the alarm still exists in storage before promoting
+                val savedAlarms = alarmStorage?.getSavedAlarms() ?: listOf()
+                if (savedAlarms.any { alarm -> alarm.id == nextId }) {
+                    Log.d(TAG, "Triggering queued alarm $nextId.")
+                    ringAlarm(nextId, nextSettings)
+                    return
+                } else {
+                    Log.d(TAG, "Queued alarm $nextId no longer exists in storage, skipping.")
+                }
+            }
         }
     }
 

--- a/android/src/main/kotlin/com/gdelataillade/alarm/alarm/AlarmService.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/alarm/AlarmService.kt
@@ -58,8 +58,10 @@ class AlarmService : Service() {
             return START_NOT_STICKY
         }
 
+        // Note: `alarmId` is only updated in ringAlarm() so that queued or
+        // stopped alarms never overwrite the id of the currently ringing
+        // alarm, which onTaskRemoved relies on.
         val id = intent.getIntExtra("id", 0)
-        alarmId = id
         val action = intent.getStringExtra(AlarmReceiver.EXTRA_ALARM_ACTION)
 
         if (action == "STOP_ALARM" && id != 0) {

--- a/android/src/main/kotlin/com/gdelataillade/alarm/api/AlarmApiImpl.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/api/AlarmApiImpl.kt
@@ -36,15 +36,12 @@ class AlarmApiImpl(private val context: Context) : AlarmApi {
 
     override fun stopAlarm(alarmId: Long, callback: (Result<Unit>) -> Unit) {
         val id = alarmId.toInt()
-        val alarmWasRinging = AlarmService.ringingAlarmIds.contains(id)
 
-        // Always deliver STOP_ALARM action to the service so it can clean up
-        // ringing alarms and remove from queue if needed.
-        val stopIntent = Intent(context, AlarmService::class.java)
-        stopIntent.action = "STOP_ALARM"
-        stopIntent.putExtra(AlarmReceiver.EXTRA_ALARM_ACTION, "STOP_ALARM")
-        stopIntent.putExtra("id", id)
-        context.startService(stopIntent)
+        // Deliver the stop to the running service so it can clean up ringing
+        // alarms and dequeue if needed. If the service isn't running, there is
+        // nothing to ring/dequeue and storage cleanup below is sufficient.
+        val serviceIsRunning = AlarmService.instance != null
+        AlarmService.instance?.handleStopAlarmCommand(id)
 
         // Intent to cancel the future alarm if it's set
         val alarmIntent = Intent(context, AlarmReceiver::class.java)
@@ -63,9 +60,9 @@ class AlarmApiImpl(private val context: Context) : AlarmApi {
         AlarmStorage(context).unsaveAlarm(id)
         updateWarningNotificationState()
 
-        // If the alarm was ringing it is the responsibility of the AlarmService to send the stop
+        // If the service was running it is the responsibility of the AlarmService to send the stop
         // signal to Flutter.
-        if (!alarmWasRinging) {
+        if (!serviceIsRunning) {
             // Notify the plugin about the alarm being stopped.
             AlarmPlugin.alarmTriggerApi?.alarmStopped(id.toLong()) {
                 if (it.isSuccess) {

--- a/android/src/main/kotlin/com/gdelataillade/alarm/api/AlarmApiImpl.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/api/AlarmApiImpl.kt
@@ -36,14 +36,15 @@ class AlarmApiImpl(private val context: Context) : AlarmApi {
 
     override fun stopAlarm(alarmId: Long, callback: (Result<Unit>) -> Unit) {
         val id = alarmId.toInt()
-        var alarmWasRinging = false
-        if (AlarmService.ringingAlarmIds.contains(id)) {
-            alarmWasRinging = true
-            val stopIntent = Intent(context, AlarmService::class.java)
-            stopIntent.action = "STOP_ALARM"
-            stopIntent.putExtra("id", id)
-            context.stopService(stopIntent)
-        }
+        val alarmWasRinging = AlarmService.ringingAlarmIds.contains(id)
+
+        // Always deliver STOP_ALARM action to the service so it can clean up
+        // ringing alarms and remove from queue if needed.
+        val stopIntent = Intent(context, AlarmService::class.java)
+        stopIntent.action = "STOP_ALARM"
+        stopIntent.putExtra(AlarmReceiver.EXTRA_ALARM_ACTION, "STOP_ALARM")
+        stopIntent.putExtra("id", id)
+        context.startService(stopIntent)
 
         // Intent to cancel the future alarm if it's set
         val alarmIntent = Intent(context, AlarmReceiver::class.java)

--- a/android/src/main/kotlin/com/gdelataillade/alarm/generated/FlutterBindings.g.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/generated/FlutterBindings.g.kt
@@ -117,6 +117,7 @@ data class AlarmSettingsWire (
   val warningNotificationOnKill: Boolean,
   val androidFullScreenIntent: Boolean,
   val allowAlarmOverlap: Boolean,
+  val allowSameSecondScheduling: Boolean,
   val iOSBackgroundAudio: Boolean,
   val androidStopAlarmOnTermination: Boolean,
   val preferConnectedAudioDevice: Boolean
@@ -134,10 +135,11 @@ data class AlarmSettingsWire (
       val warningNotificationOnKill = pigeonVar_list[7] as Boolean
       val androidFullScreenIntent = pigeonVar_list[8] as Boolean
       val allowAlarmOverlap = pigeonVar_list[9] as Boolean
-      val iOSBackgroundAudio = pigeonVar_list[10] as Boolean
-      val androidStopAlarmOnTermination = pigeonVar_list[11] as Boolean
-      val preferConnectedAudioDevice = pigeonVar_list[12] as Boolean
-      return AlarmSettingsWire(id, millisecondsSinceEpoch, assetAudioPath, volumeSettings, notificationSettings, loopAudio, vibrate, warningNotificationOnKill, androidFullScreenIntent, allowAlarmOverlap, iOSBackgroundAudio, androidStopAlarmOnTermination, preferConnectedAudioDevice)
+      val allowSameSecondScheduling = pigeonVar_list[10] as Boolean
+      val iOSBackgroundAudio = pigeonVar_list[11] as Boolean
+      val androidStopAlarmOnTermination = pigeonVar_list[12] as Boolean
+      val preferConnectedAudioDevice = pigeonVar_list[13] as Boolean
+      return AlarmSettingsWire(id, millisecondsSinceEpoch, assetAudioPath, volumeSettings, notificationSettings, loopAudio, vibrate, warningNotificationOnKill, androidFullScreenIntent, allowAlarmOverlap, allowSameSecondScheduling, iOSBackgroundAudio, androidStopAlarmOnTermination, preferConnectedAudioDevice)
     }
   }
   fun toList(): List<Any?> {
@@ -152,6 +154,7 @@ data class AlarmSettingsWire (
       warningNotificationOnKill,
       androidFullScreenIntent,
       allowAlarmOverlap,
+      allowSameSecondScheduling,
       iOSBackgroundAudio,
       androidStopAlarmOnTermination,
       preferConnectedAudioDevice,

--- a/android/src/main/kotlin/com/gdelataillade/alarm/models/AlarmSettings.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/models/AlarmSettings.kt
@@ -27,6 +27,7 @@ data class AlarmSettings(
     val warningNotificationOnKill: Boolean,
     val androidFullScreenIntent: Boolean,
     val allowAlarmOverlap: Boolean = false, // Defaults to false for backward compatibility
+    val allowSameSecondScheduling: Boolean = false, // Defaults to false for backward compatibility
     val androidStopAlarmOnTermination: Boolean = true, // Defaults to true for backward compatibility
     val preferConnectedAudioDevice: Boolean = false, // Defaults to false for backward compatibility
 ) {
@@ -43,6 +44,7 @@ data class AlarmSettings(
                 e.warningNotificationOnKill,
                 e.androidFullScreenIntent,
                 e.allowAlarmOverlap,
+                e.allowSameSecondScheduling,
                 e.androidStopAlarmOnTermination,
                 e.preferConnectedAudioDevice,
             )
@@ -69,6 +71,9 @@ data class AlarmSettings(
 
             // Handle backward compatibility for `allowAlarmOverlap`
             val allowAlarmOverlap = jsonObject.primitiveBoolean("allowAlarmOverlap") ?: false
+
+            // Handle backward compatibility for `allowSameSecondScheduling`
+            val allowSameSecondScheduling = jsonObject.primitiveBoolean("allowSameSecondScheduling") ?: false
 
             // Handle backward compatibility for `androidStopAlarmOnTermination`
             val androidStopAlarmOnTermination = jsonObject.primitiveBoolean("androidStopAlarmOnTermination") ?: true
@@ -105,6 +110,7 @@ data class AlarmSettings(
                 warningNotificationOnKill = warningNotificationOnKill,
                 androidFullScreenIntent = androidFullScreenIntent,
                 allowAlarmOverlap = allowAlarmOverlap,
+                allowSameSecondScheduling = allowSameSecondScheduling,
                 androidStopAlarmOnTermination = androidStopAlarmOnTermination,
                 preferConnectedAudioDevice = preferConnectedAudioDevice,
             )

--- a/android/src/main/kotlin/com/gdelataillade/alarm/services/AudioService.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/services/AudioService.kt
@@ -21,11 +21,10 @@ class AudioService(private val context: Context) {
 
     private val mediaPlayers = ConcurrentHashMap<Int, MediaPlayer>()
     private val timers = ConcurrentHashMap<Int, Timer>()
+    private val onAudioCompleteListeners = ConcurrentHashMap<Int, () -> Unit>()
 
-    private var onAudioComplete: (() -> Unit)? = null
-
-    fun setOnAudioCompleteListener(listener: () -> Unit) {
-        onAudioComplete = listener
+    fun setOnAudioCompleteListener(id: Int, listener: () -> Unit) {
+        onAudioCompleteListeners[id] = listener
     }
 
     fun isMediaPlayerEmpty(): Boolean {
@@ -113,7 +112,7 @@ class AudioService(private val context: Context) {
 
                 setOnCompletionListener {
                     if (!loopAudio) {
-                        onAudioComplete?.invoke()
+                        onAudioCompleteListeners[id]?.invoke()
                     }
                 }
 
@@ -136,6 +135,8 @@ class AudioService(private val context: Context) {
     }
 
     fun stopAudio(id: Int) {
+        onAudioCompleteListeners.remove(id)
+
         timers[id]?.cancel()
         timers.remove(id)
 

--- a/android/src/main/kotlin/com/gdelataillade/alarm/services/AudioService.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/services/AudioService.kt
@@ -43,7 +43,7 @@ class AudioService(private val context: Context) {
         fadeSteps: List<VolumeFadeStep>,
         preferConnectedAudioDevice: Boolean
     ) {
-        stopAudio(id) // Stop and release any existing MediaPlayer and Timer for this ID
+        releaseMediaPlayer(id) // Stop and release any existing MediaPlayer and Timer for this ID
 
         try {
             MediaPlayer().apply {
@@ -136,7 +136,13 @@ class AudioService(private val context: Context) {
 
     fun stopAudio(id: Int) {
         onAudioCompleteListeners.remove(id)
+        releaseMediaPlayer(id)
+    }
 
+    // Releases the MediaPlayer and Timer for this ID without touching the
+    // completion listener, so playAudio can clean up a previous player after
+    // the listener for the new ring has already been registered.
+    private fun releaseMediaPlayer(id: Int) {
         timers[id]?.cancel()
         timers.remove(id)
 
@@ -218,6 +224,8 @@ class AudioService(private val context: Context) {
     }
 
     fun cleanUp() {
+        onAudioCompleteListeners.clear()
+
         timers.values.forEach(Timer::cancel)
         timers.clear()
 

--- a/example/lib/screens/edit_alarm.dart
+++ b/example/lib/screens/edit_alarm.dart
@@ -48,7 +48,8 @@ class _ExampleAlarmEditScreenState extends State<ExampleAlarmEditScreen> {
       fadeDuration = widget.alarmSettings!.volumeSettings.fadeDuration;
       staircaseFade = widget.alarmSettings!.volumeSettings.fadeSteps.isNotEmpty;
       assetAudio = widget.alarmSettings!.assetAudioPath;
-      allowSameSecondScheduling = widget.alarmSettings!.allowSameSecondScheduling;
+      allowSameSecondScheduling =
+          widget.alarmSettings!.allowSameSecondScheduling;
       allowAlarmOverlap = widget.alarmSettings!.allowAlarmOverlap;
     }
   }

--- a/example/lib/screens/edit_alarm.dart
+++ b/example/lib/screens/edit_alarm.dart
@@ -21,6 +21,8 @@ class _ExampleAlarmEditScreenState extends State<ExampleAlarmEditScreen> {
   late Duration? fadeDuration;
   late bool staircaseFade;
   late String? assetAudio;
+  late bool allowSameSecondScheduling;
+  late bool allowAlarmOverlap;
 
   @override
   void initState() {
@@ -36,6 +38,8 @@ class _ExampleAlarmEditScreenState extends State<ExampleAlarmEditScreen> {
       fadeDuration = null;
       staircaseFade = false;
       assetAudio = null;
+      allowSameSecondScheduling = false;
+      allowAlarmOverlap = false;
     } else {
       selectedDateTime = widget.alarmSettings!.dateTime;
       loopAudio = widget.alarmSettings!.loopAudio;
@@ -44,6 +48,8 @@ class _ExampleAlarmEditScreenState extends State<ExampleAlarmEditScreen> {
       fadeDuration = widget.alarmSettings!.volumeSettings.fadeDuration;
       staircaseFade = widget.alarmSettings!.volumeSettings.fadeSteps.isNotEmpty;
       assetAudio = widget.alarmSettings!.assetAudioPath;
+      allowSameSecondScheduling = widget.alarmSettings!.allowSameSecondScheduling;
+      allowAlarmOverlap = widget.alarmSettings!.allowAlarmOverlap;
     }
   }
 
@@ -119,7 +125,8 @@ class _ExampleAlarmEditScreenState extends State<ExampleAlarmEditScreen> {
       vibrate: vibrate,
       assetAudioPath: assetAudio,
       volumeSettings: volumeSettings,
-      allowAlarmOverlap: true,
+      allowSameSecondScheduling: allowSameSecondScheduling,
+      allowAlarmOverlap: allowAlarmOverlap,
       notificationSettings: NotificationSettings(
         title: 'Alarm example',
         body: 'Your alarm ($id) is ringing',
@@ -323,6 +330,38 @@ class _ExampleAlarmEditScreenState extends State<ExampleAlarmEditScreen> {
                   () => fadeDuration =
                       value != null ? Duration(seconds: value) : null,
                 ),
+              ),
+            ],
+          ),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Expanded(
+                child: Text(
+                  'Same-second scheduling',
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+              ),
+              Switch(
+                value: allowSameSecondScheduling,
+                onChanged: (value) =>
+                    setState(() => allowSameSecondScheduling = value),
+              ),
+            ],
+          ),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Expanded(
+                child: Text(
+                  'Alarm overlap',
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+              ),
+              Switch(
+                value: allowAlarmOverlap,
+                onChanged: (value) =>
+                    setState(() => allowAlarmOverlap = value),
               ),
             ],
           ),

--- a/example/lib/screens/home.dart
+++ b/example/lib/screens/home.dart
@@ -170,7 +170,9 @@ class _ExampleAlarmHomeScreenState extends State<ExampleAlarmHomeScreen> {
                           onDismissed: () {
                             Alarm.stop(alarm.id).then((_) {
                               setState(() {
-                                alarmHistory.removeWhere((a) => a.id == alarm.id);
+                                alarmHistory.removeWhere(
+                                  (a) => a.id == alarm.id,
+                                );
                               });
                             });
                           },

--- a/example/lib/screens/home.dart
+++ b/example/lib/screens/home.dart
@@ -22,6 +22,7 @@ class ExampleAlarmHomeScreen extends StatefulWidget {
 
 class _ExampleAlarmHomeScreenState extends State<ExampleAlarmHomeScreen> {
   List<AlarmSettings> alarms = [];
+  final List<AlarmSettings> alarmHistory = [];
   Notifications? notifications;
 
   static StreamSubscription<AlarmSet>? ringSubscription;
@@ -42,10 +43,22 @@ class _ExampleAlarmHomeScreenState extends State<ExampleAlarmHomeScreen> {
   }
 
   Future<void> loadAlarms() async {
-    final updatedAlarms = await Alarm.getAlarms();
-    updatedAlarms.sort((a, b) => a.dateTime.isBefore(b.dateTime) ? 0 : 1);
+    final scheduled = await Alarm.getAlarms();
+
+    // Merge scheduled alarms into history, keeping stopped ones visible
+    for (final alarm in scheduled) {
+      final index = alarmHistory.indexWhere((a) => a.id == alarm.id);
+      if (index == -1) {
+        alarmHistory.add(alarm);
+      } else {
+        alarmHistory[index] = alarm;
+      }
+    }
+
+    alarmHistory.sort((a, b) => a.dateTime.isBefore(b.dateTime) ? 0 : 1);
+
     setState(() {
-      alarms = updatedAlarms;
+      alarms = scheduled;
     });
   }
 
@@ -127,22 +140,39 @@ class _ExampleAlarmHomeScreenState extends State<ExampleAlarmHomeScreen> {
         child: Column(
           children: [
             Expanded(
-              child: alarms.isNotEmpty
+              child: alarmHistory.isNotEmpty
                   ? ListView.separated(
-                      itemCount: alarms.length,
+                      itemCount: alarmHistory.length,
                       separatorBuilder: (context, index) =>
                           const Divider(height: 1),
                       itemBuilder: (context, index) {
+                        final alarm = alarmHistory[index];
+                        final isStopped = !alarms.any((a) => a.id == alarm.id);
+                        final soundName = alarm.assetAudioPath
+                            ?.split('/')
+                            .last
+                            .replaceAll('.mp3', '');
+                        final flags = <String>[
+                          'id:${alarm.id}',
+                          if (soundName != null) soundName else 'default',
+                          if (alarm.allowSameSecondScheduling) 'same-second',
+                          if (alarm.allowAlarmOverlap) 'overlap',
+                        ];
                         return ExampleAlarmTile(
-                          key: Key(alarms[index].id.toString()),
+                          key: Key(alarm.id.toString()),
                           title: TimeOfDay(
-                            hour: alarms[index].dateTime.hour,
-                            minute: alarms[index].dateTime.minute,
+                            hour: alarm.dateTime.hour,
+                            minute: alarm.dateTime.minute,
                           ).format(context),
-                          onPressed: () => navigateToAlarmScreen(alarms[index]),
+                          subtitle: flags.join(' · '),
+                          isStopped: isStopped,
+                          onPressed: () => navigateToAlarmScreen(alarm),
                           onDismissed: () {
-                            Alarm.stop(alarms[index].id)
-                                .then((_) => loadAlarms());
+                            Alarm.stop(alarm.id).then((_) {
+                              setState(() {
+                                alarmHistory.removeWhere((a) => a.id == alarm.id);
+                              });
+                            });
                           },
                         );
                       },

--- a/example/lib/screens/ring.dart
+++ b/example/lib/screens/ring.dart
@@ -26,7 +26,12 @@ class _ExampleAlarmRingScreenState extends State<ExampleAlarmRingScreen> {
       if (alarms.containsId(widget.alarmSettings.id)) return;
       _log.info('Alarm ${widget.alarmSettings.id} stopped ringing.');
       _ringingSubscription?.cancel();
-      if (mounted) Navigator.pop(context);
+      if (mounted) {
+        final route = ModalRoute.of(context);
+        if (route != null) {
+          Navigator.of(context).removeRoute(route);
+        }
+      }
     });
   }
 
@@ -44,8 +49,20 @@ class _ExampleAlarmRingScreenState extends State<ExampleAlarmRingScreen> {
           mainAxisAlignment: MainAxisAlignment.spaceAround,
           children: [
             Text(
-              'You alarm (${widget.alarmSettings.id}) is ringing...',
+              'Alarm ${widget.alarmSettings.id} is ringing',
               style: Theme.of(context).textTheme.titleLarge,
+            ),
+            Text(
+              widget.alarmSettings.allowAlarmOverlap
+                  ? 'Concurrent mode'
+                  : 'Sequential mode',
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+            Text(
+              widget.alarmSettings.allowSameSecondScheduling
+                  ? 'Same-second scheduling enabled'
+                  : '',
+              style: Theme.of(context).textTheme.bodySmall,
             ),
             const Text('🔔', style: TextStyle(fontSize: 50)),
             Row(

--- a/example/lib/screens/shortcut_button.dart
+++ b/example/lib/screens/shortcut_button.dart
@@ -66,9 +66,8 @@ class _ExampleAlarmHomeShortcutButtonState
         id: baseId + i,
         dateTime: dateTime,
         loopAudio: false,
-        vibrate: true,
         assetAudioPath: sounds[i],
-        volumeSettings: VolumeSettings.fixed(volume: 0.8),
+        volumeSettings: const VolumeSettings.fixed(volume: 0.8),
         allowSameSecondScheduling: true,
         allowAlarmOverlap: allowOverlap,
         notificationSettings: NotificationSettings(

--- a/example/lib/screens/shortcut_button.dart
+++ b/example/lib/screens/shortcut_button.dart
@@ -48,6 +48,58 @@ class _ExampleAlarmHomeShortcutButtonState
     widget.refreshAlarms();
   }
 
+  Future<void> scheduleMultipleAlarms({required bool allowOverlap}) async {
+    setState(() => showMenu = false);
+
+    final now = DateTime.now();
+    final baseId = now.millisecondsSinceEpoch % 10000;
+    final dateTime = now.add(const Duration(seconds: 5));
+
+    final sounds = [
+      'assets/marimba.mp3',
+      'assets/nokia.mp3',
+      'assets/mozart.mp3',
+    ];
+
+    for (var i = 0; i < 3; i++) {
+      final alarmSettings = AlarmSettings(
+        id: baseId + i,
+        dateTime: dateTime,
+        loopAudio: false,
+        vibrate: true,
+        assetAudioPath: sounds[i],
+        volumeSettings: VolumeSettings.fixed(volume: 0.8),
+        allowSameSecondScheduling: true,
+        allowAlarmOverlap: allowOverlap,
+        notificationSettings: NotificationSettings(
+          title: 'Alarm ${i + 1} of 3',
+          body: allowOverlap
+              ? 'Concurrent mode: overlapping alarms'
+              : 'Sequential mode: queued alarms',
+          stopButton: 'Stop',
+          icon: 'notification_icon',
+        ),
+        warningNotificationOnKill: Platform.isIOS,
+      );
+
+      await Alarm.set(alarmSettings: alarmSettings);
+    }
+
+    widget.refreshAlarms();
+
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            allowOverlap
+                ? '3 concurrent alarms scheduled for ${dateTime.toLocal()}'
+                : '3 sequential alarms scheduled for ${dateTime.toLocal()}',
+          ),
+        ),
+      );
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return Row(
@@ -82,6 +134,14 @@ class _ExampleAlarmHomeShortcutButtonState
               TextButton(
                 onPressed: () => onPressButton(48),
                 child: const Text('+48h'),
+              ),
+              TextButton(
+                onPressed: () => scheduleMultipleAlarms(allowOverlap: false),
+                child: const Text('3 seq'),
+              ),
+              TextButton(
+                onPressed: () => scheduleMultipleAlarms(allowOverlap: true),
+                child: const Text('3 overlap'),
               ),
             ],
           ),

--- a/example/lib/widgets/tile.dart
+++ b/example/lib/widgets/tile.dart
@@ -5,10 +5,14 @@ class ExampleAlarmTile extends StatelessWidget {
     required this.title,
     required this.onPressed,
     super.key,
+    this.subtitle,
+    this.isStopped = false,
     this.onDismissed,
   });
 
   final String title;
+  final String? subtitle;
+  final bool isStopped;
   final void Function() onPressed;
   final void Function()? onDismissed;
 
@@ -33,19 +37,38 @@ class ExampleAlarmTile extends StatelessWidget {
       child: RawMaterialButton(
         onPressed: onPressed,
         child: Container(
-          height: 100,
-          padding: const EdgeInsets.all(35),
+          height: subtitle != null ? 120 : 100,
+          padding: const EdgeInsets.symmetric(horizontal: 35, vertical: 20),
           child: Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
-              Text(
-                title,
-                style: const TextStyle(
-                  fontSize: 28,
-                  fontWeight: FontWeight.w500,
-                ),
+              Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    title,
+                    style: TextStyle(
+                      fontSize: 28,
+                      fontWeight: FontWeight.w500,
+                      color: isStopped ? Colors.grey[400] : Colors.black,
+                    ),
+                  ),
+                  if (subtitle != null)
+                    Text(
+                      isStopped ? 'Stopped · $subtitle' : subtitle!,
+                      style: TextStyle(
+                        fontSize: 12,
+                        color: isStopped ? Colors.grey[400] : Colors.grey[600],
+                      ),
+                    ),
+                ],
               ),
-              const Icon(Icons.keyboard_arrow_right_rounded, size: 35),
+              Icon(
+                Icons.keyboard_arrow_right_rounded,
+                size: 35,
+                color: isStopped ? Colors.grey[400] : Colors.black,
+              ),
             ],
           ),
         ),

--- a/ios/Classes/generated/FlutterBindings.g.swift
+++ b/ios/Classes/generated/FlutterBindings.g.swift
@@ -160,6 +160,7 @@ struct AlarmSettingsWire: Hashable {
   var warningNotificationOnKill: Bool
   var androidFullScreenIntent: Bool
   var allowAlarmOverlap: Bool
+  var allowSameSecondScheduling: Bool
   var iOSBackgroundAudio: Bool
   var androidStopAlarmOnTermination: Bool
   var preferConnectedAudioDevice: Bool
@@ -177,9 +178,10 @@ struct AlarmSettingsWire: Hashable {
     let warningNotificationOnKill = pigeonVar_list[7] as! Bool
     let androidFullScreenIntent = pigeonVar_list[8] as! Bool
     let allowAlarmOverlap = pigeonVar_list[9] as! Bool
-    let iOSBackgroundAudio = pigeonVar_list[10] as! Bool
-    let androidStopAlarmOnTermination = pigeonVar_list[11] as! Bool
-    let preferConnectedAudioDevice = pigeonVar_list[12] as! Bool
+    let allowSameSecondScheduling = pigeonVar_list[10] as! Bool
+    let iOSBackgroundAudio = pigeonVar_list[11] as! Bool
+    let androidStopAlarmOnTermination = pigeonVar_list[12] as! Bool
+    let preferConnectedAudioDevice = pigeonVar_list[13] as! Bool
 
     return AlarmSettingsWire(
       id: id,
@@ -192,6 +194,7 @@ struct AlarmSettingsWire: Hashable {
       warningNotificationOnKill: warningNotificationOnKill,
       androidFullScreenIntent: androidFullScreenIntent,
       allowAlarmOverlap: allowAlarmOverlap,
+      allowSameSecondScheduling: allowSameSecondScheduling,
       iOSBackgroundAudio: iOSBackgroundAudio,
       androidStopAlarmOnTermination: androidStopAlarmOnTermination,
       preferConnectedAudioDevice: preferConnectedAudioDevice
@@ -209,6 +212,7 @@ struct AlarmSettingsWire: Hashable {
       warningNotificationOnKill,
       androidFullScreenIntent,
       allowAlarmOverlap,
+      allowSameSecondScheduling,
       iOSBackgroundAudio,
       androidStopAlarmOnTermination,
       preferConnectedAudioDevice,

--- a/ios/Classes/models/AlarmSettings.swift
+++ b/ios/Classes/models/AlarmSettings.swift
@@ -11,12 +11,14 @@ struct AlarmSettings: Codable {
     let warningNotificationOnKill: Bool
     let androidFullScreenIntent: Bool
     let allowAlarmOverlap: Bool
+    let allowSameSecondScheduling: Bool
     let iOSBackgroundAudio: Bool
 
     enum CodingKeys: String, CodingKey {
         case id, dateTime, assetAudioPath, volumeSettings, notificationSettings,
              loopAudio, vibrate, warningNotificationOnKill, androidFullScreenIntent,
-             allowAlarmOverlap, iOSBackgroundAudio, volume, fadeDuration, volumeEnforced
+             allowAlarmOverlap, allowSameSecondScheduling, iOSBackgroundAudio,
+             volume, fadeDuration, volumeEnforced
     }
 
     /// Custom initializer to handle backward compatibility for older models
@@ -35,7 +37,10 @@ struct AlarmSettings: Codable {
 
         // Backward compatibility for `allowAlarmOverlap`
         allowAlarmOverlap = try container.decodeIfPresent(Bool.self, forKey: .allowAlarmOverlap) ?? false
-        
+
+        // Backward compatibility for `allowSameSecondScheduling`
+        allowSameSecondScheduling = try container.decodeIfPresent(Bool.self, forKey: .allowSameSecondScheduling) ?? false
+
         // Backward compatibility for `iOSBackgroundAudio`
         iOSBackgroundAudio = try container.decodeIfPresent(Bool.self, forKey: .iOSBackgroundAudio) ?? true
 
@@ -72,6 +77,7 @@ struct AlarmSettings: Codable {
         try container.encode(warningNotificationOnKill, forKey: .warningNotificationOnKill)
         try container.encode(androidFullScreenIntent, forKey: .androidFullScreenIntent)
         try container.encode(allowAlarmOverlap, forKey: .allowAlarmOverlap)
+        try container.encode(allowSameSecondScheduling, forKey: .allowSameSecondScheduling)
         try container.encode(iOSBackgroundAudio, forKey: .iOSBackgroundAudio)
     }
 
@@ -87,6 +93,7 @@ struct AlarmSettings: Codable {
         warningNotificationOnKill: Bool,
         androidFullScreenIntent: Bool,
         allowAlarmOverlap: Bool,
+        allowSameSecondScheduling: Bool,
         iOSBackgroundAudio: Bool
     ) {
         self.id = id
@@ -99,6 +106,7 @@ struct AlarmSettings: Codable {
         self.warningNotificationOnKill = warningNotificationOnKill
         self.androidFullScreenIntent = androidFullScreenIntent
         self.allowAlarmOverlap = allowAlarmOverlap
+        self.allowSameSecondScheduling = allowSameSecondScheduling
         self.iOSBackgroundAudio = iOSBackgroundAudio
     }
 
@@ -115,6 +123,7 @@ struct AlarmSettings: Codable {
             warningNotificationOnKill: wire.warningNotificationOnKill,
             androidFullScreenIntent: wire.androidFullScreenIntent,
             allowAlarmOverlap: wire.allowAlarmOverlap,
+            allowSameSecondScheduling: wire.allowSameSecondScheduling,
             iOSBackgroundAudio: wire.iOSBackgroundAudio
         )
     }

--- a/ios/Classes/services/AlarmManager.swift
+++ b/ios/Classes/services/AlarmManager.swift
@@ -7,6 +7,7 @@ class AlarmManager: NSObject {
     private let registrar: FlutterPluginRegistrar
 
     private var alarms: [Int: AlarmConfiguration] = [:]
+    private var ringingQueue: [Int] = []
 
     init(registrar: FlutterPluginRegistrar) {
         self.registrar = registrar
@@ -63,7 +64,9 @@ class AlarmManager: NSObject {
             NotificationManager.shared.dismissNotification(id: id)
         }
 
-        await AlarmRingManager.shared.stop()
+        let wasRinging = self.alarms[id]?.state == .ringing
+
+        await AlarmRingManager.shared.stop(id: id)
 
         if let config = self.alarms[id] {
             config.timer?.invalidate()
@@ -75,6 +78,11 @@ class AlarmManager: NSObject {
 
         await self.notifyAlarmStopped(id: id)
 
+        // If the stopped alarm was ringing, trigger the next queued alarm
+        if wasRinging {
+            self.triggerNextQueuedAlarm()
+        }
+
         os_log(.info, log: AlarmManager.logger, "Stop alarm for ID=%d complete.", id)
     }
 
@@ -82,6 +90,8 @@ class AlarmManager: NSObject {
         await NotificationManager.shared.removeAllNotifications()
 
         await AlarmRingManager.shared.stop()
+
+        self.ringingQueue.removeAll()
 
         let alarmIds = Array(self.alarms.keys)
         self.alarms.forEach { $0.value.timer?.invalidate() }
@@ -155,10 +165,17 @@ class AlarmManager: NSObject {
             return
         }
 
-        if !config.settings.allowAlarmOverlap && self.alarms.contains(where: { $1.state == .ringing }) {
-            os_log(.error, log: AlarmManager.logger, "Ignoring alarm with id %d because another alarm is already ringing.", id)
-            await self.stopAlarm(id: id, cancelNotif: true)
-            return
+        // If another alarm is already ringing
+        if self.alarms.contains(where: { $1.state == .ringing }) {
+            if !config.settings.allowAlarmOverlap {
+                // Queue for sequential ringing (like iOS system Clock app)
+                if !self.ringingQueue.contains(id) {
+                    self.ringingQueue.append(id)
+                }
+                os_log(.info, log: AlarmManager.logger, "Alarm %d queued because another alarm is already ringing.", id)
+                return
+            }
+            // allowAlarmOverlap == true: continue to ring, AlarmRingManager will override the previous one
         }
 
         if config.state == .ringing {
@@ -178,6 +195,7 @@ class AlarmManager: NSObject {
         BackgroundAudioManager.shared.stop()
 
         await AlarmRingManager.shared.start(
+            id: id,
             registrar: self.registrar,
             assetAudioPath: config.settings.assetAudioPath,
             loopAudio: config.settings.loopAudio,
@@ -236,6 +254,20 @@ class AlarmManager: NSObject {
                 }
                 continuation.resume()
             })
+        }
+    }
+
+    private func triggerNextQueuedAlarm() {
+        guard !self.ringingQueue.isEmpty else { return }
+        let nextId = self.ringingQueue.removeLast()
+        guard self.alarms[nextId] != nil else {
+            os_log(.error, log: AlarmManager.logger, "Queued alarm %d no longer exists, skipping.", nextId)
+            self.triggerNextQueuedAlarm()
+            return
+        }
+        os_log(.info, log: AlarmManager.logger, "Triggering queued alarm %d.", nextId)
+        Task {
+            await self.ringAlarm(id: nextId)
         }
     }
 

--- a/ios/Classes/services/AlarmManager.swift
+++ b/ios/Classes/services/AlarmManager.swift
@@ -166,16 +166,19 @@ class AlarmManager: NSObject {
         }
 
         // If another alarm is already ringing
-        if self.alarms.contains(where: { $1.state == .ringing }) {
-            if !config.settings.allowAlarmOverlap {
+        if !config.settings.allowAlarmOverlap && self.alarms.contains(where: { $1.state == .ringing }) {
+            if config.settings.allowSameSecondScheduling {
                 // Queue for sequential ringing (like iOS system Clock app)
                 if !self.ringingQueue.contains(id) {
                     self.ringingQueue.append(id)
                 }
                 os_log(.info, log: AlarmManager.logger, "Alarm %d queued because another alarm is already ringing.", id)
                 return
+            } else {
+                os_log(.error, log: AlarmManager.logger, "Ignoring alarm with id %d because another alarm is already ringing.", id)
+                await self.stopAlarm(id: id, cancelNotif: true)
+                return
             }
-            // allowAlarmOverlap == true: continue to ring, AlarmRingManager will override the previous one
         }
 
         if config.state == .ringing {

--- a/ios/Classes/services/AlarmRingManager.swift
+++ b/ios/Classes/services/AlarmRingManager.swift
@@ -11,13 +11,25 @@ class AlarmRingManager: NSObject {
     private var previousVolume: Float?
     private var volumeEnforcementTimer: Timer?
     private var audioPlayer: AVAudioPlayer?
+    private var currentAlarmId: Int?
 
     override private init() {
         super.init()
     }
 
-    func start(registrar: FlutterPluginRegistrar, assetAudioPath: String?, loopAudio: Bool, volumeSettings: VolumeSettings, onComplete: (() -> Void)?) async {
+    func start(id: Int, registrar: FlutterPluginRegistrar, assetAudioPath: String?, loopAudio: Bool, volumeSettings: VolumeSettings, onComplete: (() -> Void)?) async {
         let start = Date()
+
+        // If another alarm is already ringing, stop it before starting the new one
+        if let currentId = self.currentAlarmId, currentId != id {
+            os_log(.info, log: AlarmRingManager.logger, "Overriding previous alarm ID=%d with new alarm ID=%d", currentId, id)
+            self.audioPlayer?.stop()
+            self.audioPlayer = nil
+            self.volumeEnforcementTimer?.invalidate()
+            self.volumeEnforcementTimer = nil
+        }
+
+        self.currentAlarmId = id
 
         self.duckOtherAudios()
 
@@ -68,15 +80,23 @@ class AlarmRingManager: NSObject {
         os_log(.debug, log: AlarmRingManager.logger, "Alarm ring started in %.2fs.", runDuration)
     }
 
-    func stop() async {
+    func stop(id: Int? = nil) async {
+        if let id = id, self.currentAlarmId != id {
+            os_log(.debug, log: AlarmRingManager.logger,
+                "Skipping stop for alarm ID=%d because current alarm is ID=%d", id, self.currentAlarmId ?? -1)
+            return
+        }
+
         if self.volumeEnforcementTimer == nil && self.previousVolume == nil && self.audioPlayer == nil {
             os_log(.debug, log: AlarmRingManager.logger, "Alarm ringer already stopped.")
+            self.currentAlarmId = nil
             return
         }
 
         let start = Date()
 
-        self.mixOtherAudios()
+        self.audioPlayer?.stop()
+        self.audioPlayer = nil
 
         self.volumeEnforcementTimer?.invalidate()
         self.volumeEnforcementTimer = nil
@@ -86,8 +106,8 @@ class AlarmRingManager: NSObject {
             self.previousVolume = nil
         }
 
-        self.audioPlayer?.stop()
-        self.audioPlayer = nil
+        self.currentAlarmId = nil
+        self.mixOtherAudios()
 
         let runDuration = Date().timeIntervalSince(start)
         os_log(.debug, log: AlarmRingManager.logger, "Alarm ring stopped in %.2fs.", runDuration)

--- a/lib/alarm.dart
+++ b/lib/alarm.dart
@@ -75,12 +75,8 @@ class Alarm {
       if (alarm.dateTime.isAfter(now)) {
         await set(alarmSettings: alarm);
       } else {
-        if (await Alarm.isRinging(alarm.id)) {
-          _ringing.add(_ringing.value.add(alarm));
-          ringStream.add(alarm);
-        } else {
-          await stop(alarm.id);
-        }
+        // Expired alarm: always stop and clean up, do not trigger ringing
+        await stop(alarm.id);
       }
     }
   }

--- a/lib/alarm.dart
+++ b/lib/alarm.dart
@@ -95,8 +95,12 @@ class Alarm {
     final alarms = await getAlarms();
 
     for (final alarm in alarms) {
-      if (alarm.id == alarmSettings.id ||
-          alarm.dateTime.isSameSecond(alarmSettings.dateTime)) {
+      final sameId = alarm.id == alarmSettings.id;
+      final sameSecond = alarm.dateTime.isSameSecond(alarmSettings.dateTime);
+      final shouldReplaceSameSecond =
+          sameSecond && !alarmSettings.allowSameSecondScheduling;
+
+      if (sameId || shouldReplaceSameSecond) {
         await Alarm.stop(alarm.id);
       }
     }

--- a/lib/alarm.dart
+++ b/lib/alarm.dart
@@ -75,8 +75,12 @@ class Alarm {
       if (alarm.dateTime.isAfter(now)) {
         await set(alarmSettings: alarm);
       } else {
-        // Expired alarm: always stop and clean up, do not trigger ringing
-        await stop(alarm.id);
+        if (await Alarm.isRinging(alarm.id)) {
+          _ringing.add(_ringing.value.add(alarm));
+          ringStream.add(alarm);
+        } else {
+          await stop(alarm.id);
+        }
       }
     }
   }

--- a/lib/model/alarm_settings.dart
+++ b/lib/model/alarm_settings.dart
@@ -22,6 +22,7 @@ class AlarmSettings extends Equatable {
     this.warningNotificationOnKill = true,
     this.androidFullScreenIntent = true,
     this.allowAlarmOverlap = false,
+    this.allowSameSecondScheduling = false,
     this.iOSBackgroundAudio = true,
     this.androidStopAlarmOnTermination = true,
     this.preferConnectedAudioDevice = false,
@@ -56,6 +57,10 @@ class AlarmSettings extends Equatable {
 
       // Default `allowAlarmOverlap` to false for v4
       json['allowAlarmOverlap'] = json['allowAlarmOverlap'] ?? false;
+
+      // Default `allowSameSecondScheduling` to false for v4
+      json['allowSameSecondScheduling'] =
+          json['allowSameSecondScheduling'] ?? false;
 
       // Default `iOSBackgroundAudio` to true for v4
       json['iOSBackgroundAudio'] = json['iOSBackgroundAudio'] ?? true;
@@ -160,6 +165,14 @@ class AlarmSettings extends Equatable {
   /// Defaults to `false`.
   final bool allowAlarmOverlap;
 
+  /// Whether multiple alarms with different ids can be scheduled for the same
+  /// second. When `false` (default), a new alarm scheduled for the same second
+  /// as an existing one will replace it. When `true`, alarms with different ids
+  /// can coexist even if they share the same second.
+  ///
+  /// Defaults to `false`.
+  final bool allowSameSecondScheduling;
+
   /// iOS apps are killed if they remain inactive in the background. Android
   /// does not have this limitation due to native AlarmManager support.
   ///
@@ -212,6 +225,7 @@ class AlarmSettings extends Equatable {
         warningNotificationOnKill: warningNotificationOnKill,
         androidFullScreenIntent: androidFullScreenIntent,
         allowAlarmOverlap: allowAlarmOverlap,
+        allowSameSecondScheduling: allowSameSecondScheduling,
         iOSBackgroundAudio: iOSBackgroundAudio,
         androidStopAlarmOnTermination: androidStopAlarmOnTermination,
         preferConnectedAudioDevice: preferConnectedAudioDevice,
@@ -237,6 +251,7 @@ class AlarmSettings extends Equatable {
     bool? warningNotificationOnKill,
     bool? androidFullScreenIntent,
     bool? allowAlarmOverlap,
+    bool? allowSameSecondScheduling,
     bool? iOSBackgroundAudio,
     bool? androidStopAlarmOnTermination,
     bool? preferConnectedAudioDevice,
@@ -255,6 +270,8 @@ class AlarmSettings extends Equatable {
       androidFullScreenIntent:
           androidFullScreenIntent ?? this.androidFullScreenIntent,
       allowAlarmOverlap: allowAlarmOverlap ?? this.allowAlarmOverlap,
+      allowSameSecondScheduling:
+          allowSameSecondScheduling ?? this.allowSameSecondScheduling,
       iOSBackgroundAudio: iOSBackgroundAudio ?? this.iOSBackgroundAudio,
       androidStopAlarmOnTermination:
           androidStopAlarmOnTermination ?? this.androidStopAlarmOnTermination,
@@ -276,6 +293,7 @@ class AlarmSettings extends Equatable {
         warningNotificationOnKill,
         androidFullScreenIntent,
         allowAlarmOverlap,
+        allowSameSecondScheduling,
         iOSBackgroundAudio,
         androidStopAlarmOnTermination,
         preferConnectedAudioDevice,

--- a/lib/model/alarm_settings.g.dart
+++ b/lib/model/alarm_settings.g.dart
@@ -29,6 +29,8 @@ AlarmSettings _$AlarmSettingsFromJson(Map<String, dynamic> json) =>
               'androidFullScreenIntent', (v) => v as bool? ?? true),
           allowAlarmOverlap:
               $checkedConvert('allowAlarmOverlap', (v) => v as bool? ?? false),
+          allowSameSecondScheduling: $checkedConvert('allowSameSecondScheduling',
+              (v) => v as bool? ?? false),
           iOSBackgroundAudio:
               $checkedConvert('iOSBackgroundAudio', (v) => v as bool? ?? true),
           androidStopAlarmOnTermination: $checkedConvert(
@@ -53,6 +55,7 @@ Map<String, dynamic> _$AlarmSettingsToJson(AlarmSettings instance) =>
       'warningNotificationOnKill': instance.warningNotificationOnKill,
       'androidFullScreenIntent': instance.androidFullScreenIntent,
       'allowAlarmOverlap': instance.allowAlarmOverlap,
+      'allowSameSecondScheduling': instance.allowSameSecondScheduling,
       'iOSBackgroundAudio': instance.iOSBackgroundAudio,
       'androidStopAlarmOnTermination': instance.androidStopAlarmOnTermination,
       'preferConnectedAudioDevice': instance.preferConnectedAudioDevice,

--- a/lib/src/generated/platform_bindings.g.dart
+++ b/lib/src/generated/platform_bindings.g.dart
@@ -73,6 +73,7 @@ class AlarmSettingsWire {
     required this.warningNotificationOnKill,
     required this.androidFullScreenIntent,
     required this.allowAlarmOverlap,
+    required this.allowSameSecondScheduling,
     required this.iOSBackgroundAudio,
     required this.androidStopAlarmOnTermination,
     required this.preferConnectedAudioDevice,
@@ -98,6 +99,8 @@ class AlarmSettingsWire {
 
   bool allowAlarmOverlap;
 
+  bool allowSameSecondScheduling;
+
   bool iOSBackgroundAudio;
 
   bool androidStopAlarmOnTermination;
@@ -116,6 +119,7 @@ class AlarmSettingsWire {
       warningNotificationOnKill,
       androidFullScreenIntent,
       allowAlarmOverlap,
+      allowSameSecondScheduling,
       iOSBackgroundAudio,
       androidStopAlarmOnTermination,
       preferConnectedAudioDevice,
@@ -139,9 +143,10 @@ class AlarmSettingsWire {
       warningNotificationOnKill: result[7]! as bool,
       androidFullScreenIntent: result[8]! as bool,
       allowAlarmOverlap: result[9]! as bool,
-      iOSBackgroundAudio: result[10]! as bool,
-      androidStopAlarmOnTermination: result[11]! as bool,
-      preferConnectedAudioDevice: result[12]! as bool,
+      allowSameSecondScheduling: result[10]! as bool,
+      iOSBackgroundAudio: result[11]! as bool,
+      androidStopAlarmOnTermination: result[12]! as bool,
+      preferConnectedAudioDevice: result[13]! as bool,
     );
   }
 

--- a/pigeons/alarm_api.dart
+++ b/pigeons/alarm_api.dart
@@ -27,6 +27,7 @@ class AlarmSettingsWire {
     required this.warningNotificationOnKill,
     required this.androidFullScreenIntent,
     required this.allowAlarmOverlap,
+    required this.allowSameSecondScheduling,
     required this.iOSBackgroundAudio,
     required this.androidStopAlarmOnTermination,
     required this.preferConnectedAudioDevice,
@@ -42,6 +43,7 @@ class AlarmSettingsWire {
   final bool warningNotificationOnKill;
   final bool androidFullScreenIntent;
   final bool allowAlarmOverlap;
+  final bool allowSameSecondScheduling;
   final bool iOSBackgroundAudio;
   final bool androidStopAlarmOnTermination;
   final bool preferConnectedAudioDevice;


### PR DESCRIPTION
- Dart: add allowSameSecondScheduling to AlarmSettings
- iOS: implement ringing queue with LIFO order, currentAlarmId protection
- Android: implement ringing queue with LIFO order, per-id audio completion listener
- Example: add toggles and demo buttons for both strategies, keep stopped alarms in list