### PR TITLE
feat(android): let the app present a ringing alarm on its own activity

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,49 @@ Check out this interactive walkthrough of the `alarm` codebase on CodeCanvas [he
 ### Android
 Leverages a foreground service with AlarmManager scheduling to ensure alarm reliability, even if the app is terminated. Utilizes AudioManager for robust alarm sound management.
 
+#### Presenting the alarm on your own screen
+
+By default the full screen intent opens your launcher activity, so your whole
+app becomes what the lock screen shows.
+
+If you'd rather present the alarm on a dedicated screen, declare an activity
+that handles `com.gdelataillade.alarm.action.RING` and the plugin will open it
+instead:
+
+```xml
+<activity
+    android:name=".AlarmActivity"
+    android:exported="false"
+    android:launchMode="singleInstance"
+    android:taskAffinity="your.package.alarm"
+    android:excludeFromRecents="true"
+    android:showWhenLocked="true"
+    android:turnScreenOn="true">
+    <intent-filter>
+        <action android:name="com.gdelataillade.alarm.action.RING"/>
+        <category android:name="android.intent.category.DEFAULT"/>
+    </intent-filter>
+</activity>
+```
+
+A separate `taskAffinity` puts it in a task of its own, so finishing it returns
+the user to whatever the alarm interrupted instead of into your app.
+
+The launching intent carries what the screen needs to render without a Flutter
+engine, which is the normal case since a full screen intent starts the process
+without starting Flutter:
+
+| Extra | Value |
+| --- | --- |
+| `alarmId` | The alarm's id, to stop it |
+| `alarmTitle`, `alarmBody` | From `NotificationSettings` |
+| `alarmStopLabel` | `NotificationSettings.stopButton` |
+
+Stop the alarm by broadcasting `com.gdelataillade.alarm.ACTION_STOP` to
+`AlarmReceiver` with the `id` extra.
+
+Declaring no such activity keeps the previous behaviour.
+
 ### iOS
 Keeps the app awake using a silent `AVAudioPlayer` until alarm rings. When in the background, it also uses `Background App Refresh` to periodically ensure the app is still active.
 

--- a/android/src/main/kotlin/com/gdelataillade/alarm/alarm/AlarmService.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/alarm/AlarmService.kt
@@ -32,6 +32,26 @@ class AlarmService : Service() {
         // foreground without a real alarm notification to show.
         private const val PLACEHOLDER_NOTIFICATION_ID = 973_422
 
+        /**
+         * Action an application declares on the activity that should present a
+         * ringing alarm.
+         *
+         * Declaring one takes ownership of the alarm surface, so it can be a
+         * dedicated activity in its own task that shows over the lock screen
+         * and finishes when the alarm is resolved, the way platform clock
+         * applications behave. Without it the launcher activity is opened,
+         * which is the existing behaviour.
+         */
+        const val ACTION_RING = "com.gdelataillade.alarm.action.RING"
+
+        /** Alarm id, so the activity can act on the alarm it presents. */
+        const val EXTRA_ALARM_ID = "alarmId"
+
+        /** Notification title, body and stop label, already localized. */
+        const val EXTRA_ALARM_TITLE = "alarmTitle"
+        const val EXTRA_ALARM_BODY = "alarmBody"
+        const val EXTRA_ALARM_STOP_LABEL = "alarmStopLabel"
+
         var instance: AlarmService? = null
 
         @JvmStatic
@@ -124,14 +144,7 @@ class AlarmService : Service() {
 
         // Build the notification
         val notificationHandler = NotificationHandler(this)
-        val appIntent =
-            applicationContext.packageManager.getLaunchIntentForPackage(applicationContext.packageName)
-        val pendingIntent = PendingIntent.getActivity(
-            this,
-            id,
-            appIntent,
-            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
-        )
+        val pendingIntent = ringPendingIntent(id, alarmSettings)
 
         val notification = notificationHandler.buildNotification(
             alarmSettings.notificationSettings,
@@ -234,6 +247,45 @@ class AlarmService : Service() {
                 Log.d(TAG, "Keeping the warning notification on because there are other pending alarms.")
             }
         }
+    }
+
+    /**
+     * The activity a full-screen intent opens for [id].
+     *
+     * Everything the surface needs to present the alarm travels in the intent,
+     * so it can render without a Flutter engine. That is the normal case: the
+     * process is started by the full-screen intent itself, which does not
+     * start Flutter.
+     */
+    private fun ringPendingIntent(id: Int, alarmSettings: AlarmSettings): PendingIntent {
+        val ringIntent = resolveRingIntent()?.apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            putExtra(EXTRA_ALARM_ID, id)
+            putExtra(EXTRA_ALARM_TITLE, alarmSettings.notificationSettings.title)
+            putExtra(EXTRA_ALARM_BODY, alarmSettings.notificationSettings.body)
+            putExtra(EXTRA_ALARM_STOP_LABEL, alarmSettings.notificationSettings.stopButton)
+        } ?: applicationContext.packageManager
+            .getLaunchIntentForPackage(applicationContext.packageName)
+            ?: Intent()
+
+        return PendingIntent.getActivity(
+            this,
+            id,
+            ringIntent,
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+        )
+    }
+
+    /** The application's own alarm activity, or null when it declares none. */
+    private fun resolveRingIntent(): Intent? {
+        val intent = Intent(ACTION_RING).setPackage(applicationContext.packageName)
+        val resolved = applicationContext.packageManager
+            .queryIntentActivities(intent, 0)
+            .firstOrNull() ?: return null
+        return intent.setClassName(
+            resolved.activityInfo.packageName,
+            resolved.activityInfo.name
+        )
     }
 
     override fun onTaskRemoved(rootIntent: Intent?) {


### PR DESCRIPTION
### Problem

The full screen intent is built from `getLaunchIntentForPackage`, so a ringing alarm can only ever open the host's launcher activity. That makes the whole application the alarm surface:

- it boots and paints before it can route to an alarm screen, so the user sees the app's normal UI with the alarm sounding underneath;
- `showWhenLocked` has to go on the launcher activity for the alarm to appear at all, which means the lock screen exposes every screen the app has;
- resolving the alarm leaves the user inside the app rather than back where the alarm interrupted them.

Platform clock applications avoid all three by putting the alarm in a dedicated activity, in its own task, that finishes when the alarm is resolved.

### Change

An application that declares an activity handling `com.gdelataillade.alarm.action.RING` now owns the alarm surface, and the full screen intent opens that instead of the launcher.

```xml
<activity
    android:name=".AlarmActivity"
    android:exported="false"
    android:launchMode="singleInstance"
    android:taskAffinity="your.package.alarm"
    android:excludeFromRecents="true"
    android:showWhenLocked="true"
    android:turnScreenOn="true">
    <intent-filter>
        <action android:name="com.gdelataillade.alarm.action.RING"/>
        <category android:name="android.intent.category.DEFAULT"/>
    </intent-filter>
</activity>
```

Everything the screen needs to render travels in the launching intent — `alarmId`, `alarmTitle`, `alarmBody`, `alarmStopLabel` — because that screen normally runs with **no Flutter engine**: a full screen intent starts the process without starting Flutter.

### Compatibility

Declaring no such activity falls back to the launcher intent, so existing applications are unaffected. Nothing is removed and no existing API changes.

### Related

This is a stronger answer than a callback for the "what do I do when the alarm rings" question in #207 and #244: the app gets a real surface rather than a hook.

### Testing

Example app builds and runs on Android. Verified on a Samsung SM-S928B (Android 16) in a real application: with the activity declared the lock screen shows it and nothing else of the app; without it, behaviour is unchanged.
