### PR TITLE
feat(android): add a snooze action to the alarm notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 5.7.0
+* [Android] Added a snooze action to the alarm notification, via `AlarmSettings.androidSnoozeDuration` and `NotificationSettings.androidSnoozeButton`. Snoozing defers the alarm rather than stopping it, and is reported on the new `Alarm.snoozed` stream as well as through `Alarm.scheduled`. A snooze taken with no Flutter engine running is applied on the next `Alarm.init()`.
 * [Android] Alarms can now be presented on the app's own activity by declaring an intent filter for `com.gdelataillade.alarm.action.RING`, instead of always opening the launcher activity.
+* Fixed `build_runner` being unable to regenerate `lib/model/*.g.dart`, which also removes the only `dart format` violation in the package.
 
 ## 5.6.0
 * [Android] Added support for Android Gradle Plugin 9, while keeping AGP 8 compatibility.

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ await Alarm.set(alarmSettings: alarmSettings)
 | androidStopAlarmOnTermination                       | `bool`                 | Whether to stop the alarm when an Android task is terminated. Enabled by default.                                                                                                                    |
 | preferConnectedAudioDevice                          | `bool`                 | If true, routes alarm audio to a connected earphone or Bluetooth device when present, falling back to the built-in speaker if not. Uses the media volume slider instead of the alarm slider. Has no effect on iOS. Disabled by default. |
 | payload                                             | `String?`              | Optional data sent with the alarm. Caller handles serialization and parsing.                                                                                                                         |
+| androidSnoozeDuration                               | `Duration?`            | How long the snooze action defers the alarm. Android only. With a `NotificationSettings.snoozeButton` label, the notification offers a snooze that stops the ring and re-registers the alarm this far ahead. No snooze if null. |
 | [notificationSettings](#notificationsettings-model) | `NotificationSettings` | Settings for notification title, body, icon, icon color and action buttons (only stop at the moment).                                                                                                |
 | [volumeSettings](#volumesettings-model)             | `VolumeSettings`       | Settings for alarm volume and fade durations.                                                                                                                                                        |
 
@@ -107,6 +108,7 @@ The property `androidStopAlarmOnTermination` works only on Android as on iOS the
 | title                          | `String`  | Title of the alarm notification.                                                   |
 | body                           | `String`  | Body of the alarm notification.                                                    |
 | stopButton                     | `String?` | Text shown in the stop button of the alarm notification. Button not shown if null. |
+| snoozeButton                   | `String?` | Text shown in the snooze button of the alarm notification. Android only. Shown only when `AlarmSettings.androidSnoozeDuration` is also set. |
 | icon                           | `String?` | Icon to display on the notification. Only customizable on Android.                 |
 | iconColor                      | `Color?`  | Color of the notification icon. Only customizable on Android.                      |
 | keepNotificationAfterAlarmEnds | `bool`    | Keeps the notification visible after the alarm sound ends. iOS only.               |
@@ -253,6 +255,28 @@ Check out this interactive walkthrough of the `alarm` codebase on CodeCanvas [he
 
 ### Android
 Leverages a foreground service with AlarmManager scheduling to ensure alarm reliability, even if the app is terminated. Utilizes AudioManager for robust alarm sound management.
+
+#### Snooze
+
+Give an alarm a `androidSnoozeDuration` and its notification a
+`snoozeButton` label, and the notification offers a snooze that stops the
+current ring and re-registers the alarm that far ahead.
+
+A snooze is reported as `Alarm.snoozed`, never as a stop, because the alarm is
+still owed:
+
+```Dart
+Alarm.snoozed.listen((snooze) {
+  print('Alarm ${snooze.id} rings again at ${snooze.nextRingAt}');
+});
+```
+
+The button is normally pressed with **no Flutter engine running**, since the
+notification is native and the process may not be up. Each deferral is
+therefore recorded natively and replayed on the next `Alarm.init()`, so an app
+that tracks its own alarm state never misses one. Receiving both the live
+report and the replayed one is harmless: applying a snooze already applied
+changes nothing.
 
 ### iOS
 Keeps the app awake using a silent `AVAudioPlayer` until alarm rings. When in the background, it also uses `Background App Refresh` to periodically ensure the app is still active.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ await Alarm.set(alarmSettings: alarmSettings)
 | androidStopAlarmOnTermination                       | `bool`                 | Whether to stop the alarm when an Android task is terminated. Enabled by default.                                                                                                                    |
 | preferConnectedAudioDevice                          | `bool`                 | If true, routes alarm audio to a connected earphone or Bluetooth device when present, falling back to the built-in speaker if not. Uses the media volume slider instead of the alarm slider. Has no effect on iOS. Disabled by default. |
 | payload                                             | `String?`              | Optional data sent with the alarm. Caller handles serialization and parsing.                                                                                                                         |
-| androidSnoozeDuration                               | `Duration?`            | How long the snooze action defers the alarm. Android only. With a `NotificationSettings.snoozeButton` label, the notification offers a snooze that stops the ring and re-registers the alarm this far ahead. No snooze if null. |
+| androidSnoozeDuration                               | `Duration?`            | How long the snooze action defers the alarm. Android only. With a `NotificationSettings.androidSnoozeButton` label, the notification offers a snooze that stops the ring and re-registers the alarm this far ahead. Minimum one minute. No snooze if null. |
 | [notificationSettings](#notificationsettings-model) | `NotificationSettings` | Settings for notification title, body, icon, icon color and action buttons (only stop at the moment).                                                                                                |
 | [volumeSettings](#volumesettings-model)             | `VolumeSettings`       | Settings for alarm volume and fade durations.                                                                                                                                                        |
 
@@ -108,7 +108,7 @@ The property `androidStopAlarmOnTermination` works only on Android as on iOS the
 | title                          | `String`  | Title of the alarm notification.                                                   |
 | body                           | `String`  | Body of the alarm notification.                                                    |
 | stopButton                     | `String?` | Text shown in the stop button of the alarm notification. Button not shown if null. |
-| snoozeButton                   | `String?` | Text shown in the snooze button of the alarm notification. Android only. Shown only when `AlarmSettings.androidSnoozeDuration` is also set. |
+| androidSnoozeButton            | `String?` | Text shown in the snooze button of the alarm notification. Android only. Shown only when `AlarmSettings.androidSnoozeDuration` also gives it a usable duration. |
 | icon                           | `String?` | Icon to display on the notification. Only customizable on Android.                 |
 | iconColor                      | `Color?`  | Color of the notification icon. Only customizable on Android.                      |
 | keepNotificationAfterAlarmEnds | `bool`    | Keeps the notification visible after the alarm sound ends. iOS only.               |
@@ -319,7 +319,7 @@ Declaring no such activity keeps the previous behaviour.
 #### Snooze
 
 Give an alarm a `androidSnoozeDuration` and its notification a
-`snoozeButton` label, and the notification offers a snooze that stops the
+`androidSnoozeButton` label, and the notification offers a snooze that stops the
 current ring and re-registers the alarm that far ahead.
 
 A snooze is reported as `Alarm.snoozed`, never as a stop, because the alarm is

--- a/README.md
+++ b/README.md
@@ -380,6 +380,13 @@ record is kept until Dart confirms it stored the new time, so a crash in
 between loses nothing, and applying the same deferral twice does nothing the
 second time.
 
+> **Subscribe to `Alarm.snoozed` before calling `Alarm.init()`** if you want
+> those replayed deferrals. It is a plain broadcast stream with no buffering, so
+> a deferral replayed during `init()` is delivered only to listeners that
+> already exist. `Alarm.scheduled` has no such constraint — it replays its
+> latest value to new listeners — so an app that only needs the alarm's new time
+> can read it there instead.
+
 Snoozing an alarm that is not currently scheduled, or whose snooze time has
 already passed, is refused rather than applied — a deferral is never allowed to
 rewrite an alarm into the past, where the next reconciliation pass would delete

--- a/README.md
+++ b/README.md
@@ -333,9 +333,31 @@ Declaring no such activity keeps the previous behaviour.
 
 #### Snooze
 
-Give an alarm a `androidSnoozeDuration` and its notification a
-`androidSnoozeButton` label, and the notification offers a snooze that stops the
-current ring and re-registers the alarm that far ahead.
+Give an alarm an `androidSnoozeDuration` and its notification an
+`androidSnoozeButton` label, and the notification offers a snooze that stops
+the current ring and re-registers the alarm that far ahead:
+
+```Dart
+AlarmSettings(
+  // ...
+  androidSnoozeDuration: const Duration(minutes: 9),
+  notificationSettings: const NotificationSettings(
+    title: 'Wake up',
+    body: '',
+    stopButton: 'Stop',
+    androidSnoozeButton: 'Snooze',
+  ),
+);
+```
+
+Both are required. A label with no duration describes an action the platform
+cannot perform, and a duration with no label gives the user no way to invoke
+it; either on its own logs a warning and offers no snooze.
+
+The duration must be at least `AlarmSettings.minSnoozeDuration` (one minute).
+Below that, Android stops scheduling through `AlarmManager` and falls back to
+an in-process timer that survives neither app termination nor cancellation, so
+a shorter snooze could be neither guaranteed nor undone.
 
 A snooze is reported as `Alarm.snoozed`, never as a stop, because the alarm is
 still owed:
@@ -346,12 +368,28 @@ Alarm.snoozed.listen((snooze) {
 });
 ```
 
+The alarm also leaves `Alarm.ringing` and reappears in `Alarm.scheduled` with
+its new `dateTime`, so an app that tracks alarm state through those streams
+needs no special handling.
+
 The button is normally pressed with **no Flutter engine running**, since the
-notification is native and the process may not be up. Each deferral is
-therefore recorded natively and replayed on the next `Alarm.init()`, so an app
-that tracks its own alarm state never misses one. Receiving both the live
-report and the replayed one is harmless: applying a snooze already applied
-changes nothing.
+notification is native and the process may not be up. The deferral is recorded
+natively and applied on the next `Alarm.init()`, before any reconciliation, so
+your app never sees an alarm whose time moved with nothing explaining why. The
+record is kept until Dart confirms it stored the new time, so a crash in
+between loses nothing, and applying the same deferral twice does nothing the
+second time.
+
+Snoozing an alarm that is not currently scheduled, or whose snooze time has
+already passed, is refused rather than applied — a deferral is never allowed to
+rewrite an alarm into the past, where the next reconciliation pass would delete
+it.
+
+One caveat, inherited from how overlapping alarms work generally: if a snoozed
+alarm comes back round while a different alarm is ringing and
+`allowAlarmOverlap` is false, it is discarded rather than queued. Set
+`allowAlarmOverlap` or `allowSameSecondScheduling` if your app can have several
+alarms due close together.
 
 ### iOS
 Keeps the app awake using a silent `AVAudioPlayer` until alarm rings. When in the background, it also uses `Background App Refresh` to periodically ensure the app is still active.

--- a/README.md
+++ b/README.md
@@ -290,21 +290,36 @@ without starting Flutter:
 
 | Extra | Value |
 | --- | --- |
-| `alarmId` | The alarm's id, to stop it |
+| `alarmId` | The alarm's id, to act on it |
 | `alarmTitle`, `alarmBody` | From `NotificationSettings` |
 | `alarmStopLabel` | `NotificationSettings.stopButton` |
+| `alarmSnoozeLabel` | `NotificationSettings.androidSnoozeButton`, or null when this alarm cannot be snoozed |
 
-Stop the alarm by broadcasting `com.gdelataillade.alarm.ACTION_STOP` to
-`AlarmReceiver`. The receiver declares no intent filter, so the broadcast has
-to name it explicitly:
+Resolve the alarm by broadcasting to `AlarmReceiver`. The receiver declares no
+intent filter, so the broadcast has to name it explicitly:
 
 ```kotlin
-val stop = Intent(context, AlarmReceiver::class.java).apply {
-    action = "com.gdelataillade.alarm.ACTION_STOP"
-    putExtra("id", alarmId)
-}
-context.sendBroadcast(stop)
+// Dismiss the alarm.
+context.sendBroadcast(
+    Intent(context, AlarmReceiver::class.java).apply {
+        action = "com.gdelataillade.alarm.ACTION_STOP"
+        putExtra("id", alarmId)
+    }
+)
+
+// Or defer it, if alarmSnoozeLabel was non-null.
+context.sendBroadcast(
+    Intent(context, AlarmReceiver::class.java).apply {
+        action = "com.gdelataillade.alarm.ACTION_SNOOZE"
+        putExtra("id", alarmId)
+    }
+)
 ```
+
+Only offer snooze when `alarmSnoozeLabel` is non-null — it is gated on exactly
+the same condition as the notification's own snooze action, so a null label
+means the alarm has no usable snooze duration and the broadcast would be
+ignored.
 
 Your activity also becomes what tapping the notification opens, not only what
 the full screen intent opens — once declared, it is the alarm surface for both.

--- a/android/src/main/kotlin/com/gdelataillade/alarm/alarm/AlarmReceiver.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/alarm/AlarmReceiver.kt
@@ -15,6 +15,7 @@ class AlarmReceiver : BroadcastReceiver() {
         private const val TAG = "AlarmReceiver"
 
         const val ACTION_ALARM_STOP = "com.gdelataillade.alarm.ACTION_STOP"
+        const val ACTION_ALARM_SNOOZE = "com.gdelataillade.alarm.ACTION_SNOOZE"
     }
 
     override fun onReceive(context: Context, intent: Intent) {
@@ -39,6 +40,14 @@ class AlarmReceiver : BroadcastReceiver() {
                     Log.d(TAG, "Alarm stopped notification for $id processed by Flutter: ${it.isSuccess}")
                 }
             }
+            return
+        }
+
+        // Defer the alarm from the notification's snooze action.
+        if (intent.action == ACTION_ALARM_SNOOZE) {
+            val id = intent.getIntExtra("id", 0)
+            Log.d(TAG, "Received snooze alarm command, id: $id")
+            AlarmService.instance?.handleSnoozeAlarmCommand(id)
             return
         }
 

--- a/android/src/main/kotlin/com/gdelataillade/alarm/alarm/AlarmReceiver.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/alarm/AlarmReceiver.kt
@@ -7,6 +7,7 @@ import android.content.Intent
 import android.os.Build
 import com.gdelataillade.alarm.services.AlarmStorage
 import com.gdelataillade.alarm.services.NotificationHandler
+import com.gdelataillade.alarm.services.SnoozeCoordinator
 
 import io.flutter.Log
 
@@ -47,7 +48,12 @@ class AlarmReceiver : BroadcastReceiver() {
         if (intent.action == ACTION_ALARM_SNOOZE) {
             val id = intent.getIntExtra("id", 0)
             Log.d(TAG, "Received snooze alarm command, id: $id")
-            AlarmService.instance?.handleSnoozeAlarmCommand(id)
+            // Handled through the coordinator rather than the service, which may
+            // have been killed while its notification lingered. Going through
+            // AlarmService.instance? here would make the snooze a silent no-op
+            // in exactly that case: notification left up, alarm never
+            // rescheduled, nothing reported.
+            SnoozeCoordinator.snooze(context, id)
             return
         }
 

--- a/android/src/main/kotlin/com/gdelataillade/alarm/alarm/AlarmService.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/alarm/AlarmService.kt
@@ -20,7 +20,7 @@ import com.gdelataillade.alarm.models.AlarmSettings
 import com.gdelataillade.alarm.models.NotificationSettings
 import com.gdelataillade.alarm.services.AlarmRingingLiveData
 import com.gdelataillade.alarm.services.NotificationHandler
-import com.gdelataillade.alarm.services.NotificationOnKillService
+import com.gdelataillade.alarm.services.WarningNotificationState
 import com.gdelataillade.alarm.services.SnoozeCoordinator
 import io.flutter.Log
 import kotlinx.serialization.json.Json
@@ -250,9 +250,10 @@ class AlarmService : Service() {
         if (storage != null) {
             val storedAlarms = storage.getSavedAlarms()
             if (storedAlarms.isEmpty() || storedAlarms.all { it.id == id }) {
-                val serviceIntent = Intent(this, NotificationOnKillService::class.java)
-                // If the service isn't running this call will be ignored.
-                this.stopService(serviceIntent)
+                // An alarm that is currently ringing does not need a kill
+                // warning. If it is snoozed rather than stopped, rescheduling
+                // restores the warning via WarningNotificationState.refresh.
+                WarningNotificationState.disable(this)
                 Log.d(TAG, "Turning off the warning notification.")
             } else {
                 Log.d(TAG, "Keeping the warning notification on because there are other pending alarms.")

--- a/android/src/main/kotlin/com/gdelataillade/alarm/alarm/AlarmService.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/alarm/AlarmService.kt
@@ -1,6 +1,5 @@
 package com.gdelataillade.alarm.alarm
 
-import com.gdelataillade.alarm.api.AlarmApiImpl
 import com.gdelataillade.alarm.services.AudioService
 import com.gdelataillade.alarm.services.AlarmStorage
 import com.gdelataillade.alarm.services.VibrationService
@@ -22,9 +21,9 @@ import com.gdelataillade.alarm.models.NotificationSettings
 import com.gdelataillade.alarm.services.AlarmRingingLiveData
 import com.gdelataillade.alarm.services.NotificationHandler
 import com.gdelataillade.alarm.services.NotificationOnKillService
+import com.gdelataillade.alarm.services.SnoozeCoordinator
 import io.flutter.Log
 import kotlinx.serialization.json.Json
-import java.util.Date
 
 class AlarmService : Service() {
     companion object {
@@ -372,45 +371,13 @@ class AlarmService : Service() {
     }
 
     /**
-     * Defers [alarmId] by its own snooze duration.
+     * Silences [alarmId] without unsaving it or telling Flutter it stopped.
      *
-     * The alarm is silenced and re-registered rather than unsaved, so it never
-     * reaches Flutter as a stop: a snoozed alarm is still owed.
+     * Only for [SnoozeCoordinator], and only once it has armed the replacement:
+     * the alarm is still owed, so none of the stop bookkeeping applies.
      */
-    fun handleSnoozeAlarmCommand(alarmId: Int) {
-        if (alarmId == 0) return
-
-        val settings = queuedAlarmSettings[alarmId]
-            ?: alarmStorage?.getSavedAlarms()?.firstOrNull { it.id == alarmId }
-        if (settings == null || !settings.canSnooze) {
-            Log.d(TAG, "Alarm $alarmId cannot be snoozed; stopping instead.")
-            unsaveAlarm(alarmId)
-            return
-        }
-
-        val nextRingAt =
-            System.currentTimeMillis() + settings.androidSnoozeDurationMillis!!
-
-        // Silence first: an alarm that is both ringing and scheduled would
-        // keep the foreground service alive over a deferral.
+    fun silenceForSnooze(alarmId: Int) {
         stopAlarm(alarmId)
-
-        // Reuse the ordinary scheduling path so a snooze is registered exactly
-        // like any other alarm, including its storage entry.
-        AlarmApiImpl(applicationContext).setAlarm(settings.copy(dateTime = Date(nextRingAt)))
-
-        // Record it before reporting it. The usual case is that no Flutter
-        // engine exists, so the report below reaches nobody and this durable
-        // record is the only thing that survives. An isolate that receives
-        // both sees the same deferral twice, which is harmless: applying a
-        // snooze already applied changes nothing.
-        alarmStorage?.saveSnooze(alarmId, nextRingAt)
-
-        AlarmPlugin.alarmTriggerApi?.alarmSnoozed(alarmId.toLong(), nextRingAt) {
-            if (it.isFailure) {
-                Log.d(TAG, "Snooze notification for $alarmId errored in Flutter.")
-            }
-        }
     }
 
     private fun unsaveAlarm(id: Int) {

--- a/android/src/main/kotlin/com/gdelataillade/alarm/alarm/AlarmService.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/alarm/AlarmService.kt
@@ -1,5 +1,6 @@
 package com.gdelataillade.alarm.alarm
 
+import com.gdelataillade.alarm.api.AlarmApiImpl
 import com.gdelataillade.alarm.services.AudioService
 import com.gdelataillade.alarm.services.AlarmStorage
 import com.gdelataillade.alarm.services.VibrationService
@@ -23,6 +24,7 @@ import com.gdelataillade.alarm.services.NotificationHandler
 import com.gdelataillade.alarm.services.NotificationOnKillService
 import io.flutter.Log
 import kotlinx.serialization.json.Json
+import java.util.Date
 
 class AlarmService : Service() {
     companion object {
@@ -137,7 +139,8 @@ class AlarmService : Service() {
             alarmSettings.notificationSettings,
             alarmSettings.androidFullScreenIntent,
             pendingIntent,
-            id
+            id,
+            alarmSettings.canSnooze
         )
 
         // Start the service in the foreground
@@ -312,6 +315,48 @@ class AlarmService : Service() {
     fun handleStopAlarmCommand(alarmId: Int) {
         if (alarmId == 0) return
         unsaveAlarm(alarmId)
+    }
+
+    /**
+     * Defers [alarmId] by its own snooze duration.
+     *
+     * The alarm is silenced and re-registered rather than unsaved, so it never
+     * reaches Flutter as a stop: a snoozed alarm is still owed.
+     */
+    fun handleSnoozeAlarmCommand(alarmId: Int) {
+        if (alarmId == 0) return
+
+        val settings = queuedAlarmSettings[alarmId]
+            ?: alarmStorage?.getSavedAlarms()?.firstOrNull { it.id == alarmId }
+        if (settings == null || !settings.canSnooze) {
+            Log.d(TAG, "Alarm $alarmId cannot be snoozed; stopping instead.")
+            unsaveAlarm(alarmId)
+            return
+        }
+
+        val nextRingAt =
+            System.currentTimeMillis() + settings.androidSnoozeDurationSeconds!! * 1000L
+
+        // Silence first: an alarm that is both ringing and scheduled would
+        // keep the foreground service alive over a deferral.
+        stopAlarm(alarmId)
+
+        // Reuse the ordinary scheduling path so a snooze is registered exactly
+        // like any other alarm, including its storage entry.
+        AlarmApiImpl(applicationContext).setAlarm(settings.copy(dateTime = Date(nextRingAt)))
+
+        // Record it before reporting it. The usual case is that no Flutter
+        // engine exists, so the report below reaches nobody and this durable
+        // record is the only thing that survives. An isolate that receives
+        // both sees the same deferral twice, which is harmless: applying a
+        // snooze already applied changes nothing.
+        alarmStorage?.saveSnooze(alarmId, nextRingAt)
+
+        AlarmPlugin.alarmTriggerApi?.alarmSnoozed(alarmId.toLong(), nextRingAt) {
+            if (it.isFailure) {
+                Log.d(TAG, "Snooze notification for $alarmId errored in Flutter.")
+            }
+        }
     }
 
     private fun unsaveAlarm(id: Int) {

--- a/android/src/main/kotlin/com/gdelataillade/alarm/alarm/AlarmService.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/alarm/AlarmService.kt
@@ -389,7 +389,7 @@ class AlarmService : Service() {
         }
 
         val nextRingAt =
-            System.currentTimeMillis() + settings.androidSnoozeDurationSeconds!! * 1000L
+            System.currentTimeMillis() + settings.androidSnoozeDurationMillis!!
 
         // Silence first: an alarm that is both ringing and scheduled would
         // keep the foreground service alive over a deferral.

--- a/android/src/main/kotlin/com/gdelataillade/alarm/alarm/AlarmService.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/alarm/AlarmService.kt
@@ -53,6 +53,15 @@ class AlarmService : Service() {
         const val EXTRA_ALARM_BODY = "alarmBody"
         const val EXTRA_ALARM_STOP_LABEL = "alarmStopLabel"
 
+        /**
+         * Snooze label, already localized, or null when this alarm cannot be
+         * snoozed.
+         *
+         * Gated on the same condition as the notification's snooze action, so
+         * an activity can offer snooze exactly when the notification would.
+         */
+        const val EXTRA_ALARM_SNOOZE_LABEL = "alarmSnoozeLabel"
+
         var instance: AlarmService? = null
 
         @JvmStatic
@@ -266,6 +275,11 @@ class AlarmService : Service() {
             putExtra(EXTRA_ALARM_TITLE, alarmSettings.notificationSettings.title)
             putExtra(EXTRA_ALARM_BODY, alarmSettings.notificationSettings.body)
             putExtra(EXTRA_ALARM_STOP_LABEL, alarmSettings.notificationSettings.stopButton)
+            putExtra(
+                EXTRA_ALARM_SNOOZE_LABEL,
+                alarmSettings.notificationSettings.androidSnoozeButton
+                    ?.takeIf { alarmSettings.canSnooze }
+            )
         } ?: applicationContext.packageManager
             .getLaunchIntentForPackage(applicationContext.packageName)
             ?: Intent()

--- a/android/src/main/kotlin/com/gdelataillade/alarm/api/AlarmApiImpl.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/api/AlarmApiImpl.kt
@@ -14,7 +14,7 @@ import com.gdelataillade.alarm.models.AlarmSettings
 import com.gdelataillade.alarm.services.AlarmScheduler
 import com.gdelataillade.alarm.services.AlarmStorage
 import com.gdelataillade.alarm.services.NotificationHandler
-import com.gdelataillade.alarm.services.NotificationOnKillService
+import com.gdelataillade.alarm.services.WarningNotificationState
 import io.flutter.Log
 
 class AlarmApiImpl(private val context: Context) : AlarmApi {
@@ -23,9 +23,6 @@ class AlarmApiImpl(private val context: Context) : AlarmApi {
     }
 
     private val alarmIds: MutableList<Int> = mutableListOf()
-    private var notificationOnKillTitle: String = "Your alarms may not ring"
-    private var notificationOnKillBody: String =
-        "You killed the app. Please reopen so your alarms can be rescheduled."
 
     override fun setAlarm(alarmSettings: AlarmSettingsWire, callback: (Result<Unit>) -> Unit) {
         setAlarm(AlarmSettings.fromWire(alarmSettings))
@@ -56,7 +53,7 @@ class AlarmApiImpl(private val context: Context) : AlarmApi {
 
         alarmIds.remove(id)
         AlarmStorage(context).unsaveAlarm(id)
-        updateWarningNotificationState()
+        WarningNotificationState.refresh(context)
 
         // If the service was running it is the responsibility of the AlarmService to send the stop
         // signal to Flutter.
@@ -99,16 +96,15 @@ class AlarmApiImpl(private val context: Context) : AlarmApi {
     }
 
     override fun setWarningNotificationOnKill(title: String, body: String) {
-        notificationOnKillTitle = title
-        notificationOnKillBody = body
+        WarningNotificationState.setText(context, title, body)
 
-        // Re-create if needed.
-        turnOffWarningNotificationOnKill(context)
-        updateWarningNotificationState()
+        // Re-create so the new text takes effect if it is already showing.
+        WarningNotificationState.disable(context)
+        WarningNotificationState.refresh(context)
     }
 
     override fun disableWarningNotificationOnKill() {
-        turnOffWarningNotificationOnKill(context)
+        WarningNotificationState.disable(context)
     }
 
     override fun getPendingSnoozes(callback: (Result<List<PendingSnoozeWire>>) -> Unit) {
@@ -143,40 +139,6 @@ class AlarmApiImpl(private val context: Context) : AlarmApi {
         // reuse them without also inheriting the stop-and-replace preamble
         // above, which would report the deferral to Flutter as a stop.
         AlarmScheduler.schedule(context, alarm)
-
-        updateWarningNotificationState()
     }
 
-    private fun updateWarningNotificationState() {
-        if (AlarmStorage(context).getSavedAlarms().any { it.warningNotificationOnKill } ) {
-            turnOnWarningNotificationOnKill(context)
-        } else {
-            turnOffWarningNotificationOnKill(context)
-        }
-    }
-
-    private fun turnOnWarningNotificationOnKill(context: Context) {
-        if (NotificationOnKillService.isRunning) {
-            Log.d(TAG, "Warning notification is already turned on.")
-            return
-        }
-
-        val serviceIntent = Intent(context, NotificationOnKillService::class.java)
-        serviceIntent.putExtra("title", notificationOnKillTitle)
-        serviceIntent.putExtra("body", notificationOnKillBody)
-
-        context.startService(serviceIntent)
-        Log.d(TAG, "Warning notification turned on.")
-    }
-
-    private fun turnOffWarningNotificationOnKill(context: Context) {
-        if (!NotificationOnKillService.isRunning) {
-            Log.d(TAG, "Warning notification is already turned off.")
-            return
-        }
-
-        val serviceIntent = Intent(context, NotificationOnKillService::class.java)
-        context.stopService(serviceIntent)
-        Log.d(TAG, "Warning notification turned off.")
-    }
 }

--- a/android/src/main/kotlin/com/gdelataillade/alarm/api/AlarmApiImpl.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/api/AlarmApiImpl.kt
@@ -7,19 +7,15 @@ import android.app.AlarmManager
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
-import android.os.Build
-import android.os.Handler
-import android.os.Looper
 import com.gdelataillade.alarm.alarm.AlarmPlugin
 import com.gdelataillade.alarm.alarm.AlarmReceiver
 import com.gdelataillade.alarm.alarm.AlarmService
 import com.gdelataillade.alarm.models.AlarmSettings
+import com.gdelataillade.alarm.services.AlarmScheduler
 import com.gdelataillade.alarm.services.AlarmStorage
 import com.gdelataillade.alarm.services.NotificationHandler
 import com.gdelataillade.alarm.services.NotificationOnKillService
 import io.flutter.Log
-import kotlinx.serialization.encodeToString
-import kotlinx.serialization.json.Json
 
 class AlarmApiImpl(private val context: Context) : AlarmApi {
     companion object {
@@ -141,112 +137,14 @@ class AlarmApiImpl(private val context: Context) : AlarmApi {
             stopAlarm(alarm.id.toLong()) {}
         }
 
-        val alarmIntent = createAlarmIntent(alarm)
-        // Keep millisecond precision so alarms ring at the exact requested
-        // time instead of up to a second early.
-        val delayInMillis = alarm.dateTime.time - System.currentTimeMillis()
-
         alarmIds.add(alarm.id)
-        AlarmStorage(context).saveAlarm(alarm)
 
-        if (delayInMillis <= 5000L) {
-            handleImmediateAlarm(alarmIntent, delayInMillis)
-        } else {
-            handleDelayedAlarm(alarmIntent, alarm.dateTime.time, alarm.id)
-        }
+        // Persisting and arming live in AlarmScheduler so the snooze path can
+        // reuse them without also inheriting the stop-and-replace preamble
+        // above, which would report the deferral to Flutter as a stop.
+        AlarmScheduler.schedule(context, alarm)
 
         updateWarningNotificationState()
-    }
-
-    private fun createAlarmIntent(alarm: AlarmSettings): Intent {
-        val alarmIntent = Intent(context, AlarmReceiver::class.java)
-        alarmIntent.putExtra("id", alarm.id)
-        alarmIntent.putExtra("alarmSettings", Json.encodeToString(alarm))
-        return alarmIntent
-    }
-
-    private fun handleImmediateAlarm(intent: Intent, delayInMillis: Long) {
-        val handler = Handler(Looper.getMainLooper())
-        handler.postDelayed({
-            context.sendBroadcast(intent)
-        }, delayInMillis.coerceAtLeast(0L))
-    }
-
-    private fun handleDelayedAlarm(
-        intent: Intent,
-        triggerTimeMillis: Long,
-        id: Int,
-    ) {
-        try {
-            val pendingIntent = PendingIntent.getBroadcast(
-                context,
-                id,
-                intent,
-                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-            )
-
-            val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as? AlarmManager
-                ?: throw IllegalStateException("AlarmManager not available")
-
-            setExactAlarm(alarmManager, triggerTimeMillis, pendingIntent)
-        } catch (e: ClassCastException) {
-            Log.e(TAG, "AlarmManager service type casting failed", e)
-        } catch (e: IllegalStateException) {
-            Log.e(TAG, "AlarmManager service not available", e)
-        } catch (e: Exception) {
-            Log.e(TAG, "Error in handling delayed alarm", e)
-        }
-    }
-
-    private fun setExactAlarm(
-        alarmManager: AlarmManager,
-        triggerTimeMillis: Long,
-        pendingIntent: PendingIntent,
-    ) {
-        // On Android 12+ the user can revoke the exact alarm permission at any
-        // time. Fall back to an inexact alarm instead of silently scheduling
-        // nothing: the alarm may ring a few minutes late, but it will ring.
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
-            !alarmManager.canScheduleExactAlarms()
-        ) {
-            Log.w(
-                TAG,
-                "SCHEDULE_EXACT_ALARM permission not granted. Falling back to an " +
-                    "inexact alarm, which may ring late. Ask the user to grant the " +
-                    "'Alarms & reminders' permission for exact scheduling."
-            )
-            alarmManager.setAndAllowWhileIdle(
-                AlarmManager.RTC_WAKEUP,
-                triggerTimeMillis,
-                pendingIntent
-            )
-            return
-        }
-
-        try {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                alarmManager.setExactAndAllowWhileIdle(
-                    AlarmManager.RTC_WAKEUP,
-                    triggerTimeMillis,
-                    pendingIntent
-                )
-            } else {
-                alarmManager.setExact(AlarmManager.RTC_WAKEUP, triggerTimeMillis, pendingIntent)
-            }
-        } catch (e: SecurityException) {
-            // Defensive: the permission state changed between the check above
-            // and the call, or an OEM enforces it on older API levels.
-            Log.e(TAG, "Exact alarm scheduling rejected; falling back to inexact alarm", e)
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                alarmManager.setAndAllowWhileIdle(
-                    AlarmManager.RTC_WAKEUP,
-                    triggerTimeMillis,
-                    pendingIntent
-                )
-            } else {
-                alarmManager.set(AlarmManager.RTC_WAKEUP, triggerTimeMillis, pendingIntent)
-            }
-        }
     }
 
     private fun updateWarningNotificationState() {

--- a/android/src/main/kotlin/com/gdelataillade/alarm/api/AlarmApiImpl.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/api/AlarmApiImpl.kt
@@ -2,7 +2,7 @@ package com.gdelataillade.alarm.api
 
 import com.gdelataillade.alarm.generated.AlarmApi
 import com.gdelataillade.alarm.generated.AlarmSettingsWire
-import com.gdelataillade.alarm.generated.SnoozedAlarmWire
+import com.gdelataillade.alarm.generated.PendingSnoozeWire
 import android.app.AlarmManager
 import android.app.PendingIntent
 import android.content.Context
@@ -115,15 +115,24 @@ class AlarmApiImpl(private val context: Context) : AlarmApi {
         turnOffWarningNotificationOnKill(context)
     }
 
-    override fun takeUnreportedSnoozes(callback: (Result<List<SnoozedAlarmWire>>) -> Unit) {
-        val snoozes = AlarmStorage(context).takeSnoozes()
+    override fun getPendingSnoozes(callback: (Result<List<PendingSnoozeWire>>) -> Unit) {
+        val snoozes = AlarmStorage(context).getPendingSnoozes()
         callback(
             Result.success(
                 snoozes.map { (id, nextRingAt) ->
-                    SnoozedAlarmWire(id.toLong(), nextRingAt)
+                    PendingSnoozeWire(id.toLong(), nextRingAt)
                 }
             )
         )
+    }
+
+    override fun acknowledgeSnooze(
+        alarmId: Long,
+        nextRingAtMillis: Long,
+        callback: (Result<Unit>) -> Unit,
+    ) {
+        AlarmStorage(context).acknowledgeSnooze(alarmId.toInt(), nextRingAtMillis)
+        callback(Result.success(Unit))
     }
 
     fun setAlarm(alarm: AlarmSettings) {

--- a/android/src/main/kotlin/com/gdelataillade/alarm/api/AlarmApiImpl.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/api/AlarmApiImpl.kt
@@ -2,6 +2,7 @@ package com.gdelataillade.alarm.api
 
 import com.gdelataillade.alarm.generated.AlarmApi
 import com.gdelataillade.alarm.generated.AlarmSettingsWire
+import com.gdelataillade.alarm.generated.SnoozedAlarmWire
 import android.app.AlarmManager
 import android.app.PendingIntent
 import android.content.Context
@@ -112,6 +113,17 @@ class AlarmApiImpl(private val context: Context) : AlarmApi {
 
     override fun disableWarningNotificationOnKill() {
         turnOffWarningNotificationOnKill(context)
+    }
+
+    override fun takeUnreportedSnoozes(callback: (Result<List<SnoozedAlarmWire>>) -> Unit) {
+        val snoozes = AlarmStorage(context).takeSnoozes()
+        callback(
+            Result.success(
+                snoozes.map { (id, nextRingAt) ->
+                    SnoozedAlarmWire(id.toLong(), nextRingAt)
+                }
+            )
+        )
     }
 
     fun setAlarm(alarm: AlarmSettings) {

--- a/android/src/main/kotlin/com/gdelataillade/alarm/generated/FlutterBindings.g.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/generated/FlutterBindings.g.kt
@@ -272,7 +272,7 @@ data class NotificationSettingsWire (
    * gives it a usable duration; a label alone describes nothing the platform
    * can perform. Android only.
    */
-  val snoozeButton: String? = null
+  val androidSnoozeButton: String? = null
 )
  {
   companion object {
@@ -286,8 +286,8 @@ data class NotificationSettingsWire (
       val iconColorGreen = pigeonVar_list[6] as Double?
       val iconColorBlue = pigeonVar_list[7] as Double?
       val keepNotificationAfterAlarmEnds = pigeonVar_list[8] as Boolean
-      val snoozeButton = pigeonVar_list[9] as String?
-      return NotificationSettingsWire(title, body, stopButton, icon, iconColorAlpha, iconColorRed, iconColorGreen, iconColorBlue, keepNotificationAfterAlarmEnds, snoozeButton)
+      val androidSnoozeButton = pigeonVar_list[9] as String?
+      return NotificationSettingsWire(title, body, stopButton, icon, iconColorAlpha, iconColorRed, iconColorGreen, iconColorBlue, keepNotificationAfterAlarmEnds, androidSnoozeButton)
     }
   }
   fun toList(): List<Any?> {
@@ -301,7 +301,7 @@ data class NotificationSettingsWire (
       iconColorGreen,
       iconColorBlue,
       keepNotificationAfterAlarmEnds,
-      snoozeButton,
+      androidSnoozeButton,
     )
   }
   override fun equals(other: Any?): Boolean {

--- a/android/src/main/kotlin/com/gdelataillade/alarm/generated/FlutterBindings.g.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/generated/FlutterBindings.g.kt
@@ -120,7 +120,13 @@ data class AlarmSettingsWire (
   val allowSameSecondScheduling: Boolean,
   val iOSBackgroundAudio: Boolean,
   val androidStopAlarmOnTermination: Boolean,
-  val preferConnectedAudioDevice: Boolean
+  val preferConnectedAudioDevice: Boolean,
+  /**
+   * How long the snooze action defers the alarm, in seconds.
+   *
+   * Null, or anything below one, offers no snooze. Android only.
+   */
+  val androidSnoozeDurationSeconds: Long? = null
 )
  {
   companion object {
@@ -139,7 +145,8 @@ data class AlarmSettingsWire (
       val iOSBackgroundAudio = pigeonVar_list[11] as Boolean
       val androidStopAlarmOnTermination = pigeonVar_list[12] as Boolean
       val preferConnectedAudioDevice = pigeonVar_list[13] as Boolean
-      return AlarmSettingsWire(id, millisecondsSinceEpoch, assetAudioPath, volumeSettings, notificationSettings, loopAudio, vibrate, warningNotificationOnKill, androidFullScreenIntent, allowAlarmOverlap, allowSameSecondScheduling, iOSBackgroundAudio, androidStopAlarmOnTermination, preferConnectedAudioDevice)
+      val androidSnoozeDurationSeconds = pigeonVar_list[14] as Long?
+      return AlarmSettingsWire(id, millisecondsSinceEpoch, assetAudioPath, volumeSettings, notificationSettings, loopAudio, vibrate, warningNotificationOnKill, androidFullScreenIntent, allowAlarmOverlap, allowSameSecondScheduling, iOSBackgroundAudio, androidStopAlarmOnTermination, preferConnectedAudioDevice, androidSnoozeDurationSeconds)
     }
   }
   fun toList(): List<Any?> {
@@ -158,6 +165,7 @@ data class AlarmSettingsWire (
       iOSBackgroundAudio,
       androidStopAlarmOnTermination,
       preferConnectedAudioDevice,
+      androidSnoozeDurationSeconds,
     )
   }
   override fun equals(other: Any?): Boolean {
@@ -253,7 +261,15 @@ data class NotificationSettingsWire (
   val iconColorRed: Double? = null,
   val iconColorGreen: Double? = null,
   val iconColorBlue: Double? = null,
-  val keepNotificationAfterAlarmEnds: Boolean
+  val keepNotificationAfterAlarmEnds: Boolean,
+  /**
+   * Label for the snooze action. Null omits the action.
+   *
+   * Only shown when [AlarmSettingsWire.androidSnoozeDurationSeconds] also
+   * gives it a duration; a label alone describes nothing the platform can
+   * perform. Android only.
+   */
+  val snoozeButton: String? = null
 )
  {
   companion object {
@@ -267,7 +283,8 @@ data class NotificationSettingsWire (
       val iconColorGreen = pigeonVar_list[6] as Double?
       val iconColorBlue = pigeonVar_list[7] as Double?
       val keepNotificationAfterAlarmEnds = pigeonVar_list[8] as Boolean
-      return NotificationSettingsWire(title, body, stopButton, icon, iconColorAlpha, iconColorRed, iconColorGreen, iconColorBlue, keepNotificationAfterAlarmEnds)
+      val snoozeButton = pigeonVar_list[9] as String?
+      return NotificationSettingsWire(title, body, stopButton, icon, iconColorAlpha, iconColorRed, iconColorGreen, iconColorBlue, keepNotificationAfterAlarmEnds, snoozeButton)
     }
   }
   fun toList(): List<Any?> {
@@ -281,10 +298,46 @@ data class NotificationSettingsWire (
       iconColorGreen,
       iconColorBlue,
       keepNotificationAfterAlarmEnds,
+      snoozeButton,
     )
   }
   override fun equals(other: Any?): Boolean {
     if (other !is NotificationSettingsWire) {
+      return false
+    }
+    if (this === other) {
+      return true
+    }
+    return FlutterBindingsPigeonUtils.deepEquals(toList(), other.toList())  }
+
+  override fun hashCode(): Int = toList().hashCode()
+}
+
+/**
+ * One deferral taken on the host side.
+ *
+ * Generated class from Pigeon that represents data sent in messages.
+ */
+data class SnoozedAlarmWire (
+  val alarmId: Long,
+  val millisecondsSinceEpoch: Long
+)
+ {
+  companion object {
+    fun fromList(pigeonVar_list: List<Any?>): SnoozedAlarmWire {
+      val alarmId = pigeonVar_list[0] as Long
+      val millisecondsSinceEpoch = pigeonVar_list[1] as Long
+      return SnoozedAlarmWire(alarmId, millisecondsSinceEpoch)
+    }
+  }
+  fun toList(): List<Any?> {
+    return listOf(
+      alarmId,
+      millisecondsSinceEpoch,
+    )
+  }
+  override fun equals(other: Any?): Boolean {
+    if (other !is SnoozedAlarmWire) {
       return false
     }
     if (this === other) {
@@ -322,6 +375,11 @@ private open class FlutterBindingsPigeonCodec : StandardMessageCodec() {
           NotificationSettingsWire.fromList(it)
         }
       }
+      134.toByte() -> {
+        return (readValue(buffer) as? List<Any?>)?.let {
+          SnoozedAlarmWire.fromList(it)
+        }
+      }
       else -> super.readValueOfType(type, buffer)
     }
   }
@@ -347,6 +405,10 @@ private open class FlutterBindingsPigeonCodec : StandardMessageCodec() {
         stream.write(133)
         writeValue(stream, value.toList())
       }
+      is SnoozedAlarmWire -> {
+        stream.write(134)
+        writeValue(stream, value.toList())
+      }
       else -> super.writeValue(stream, value)
     }
   }
@@ -361,6 +423,17 @@ interface AlarmApi {
   fun isRinging(alarmId: Long?): Boolean
   fun setWarningNotificationOnKill(title: String, body: String)
   fun disableWarningNotificationOnKill()
+  /**
+   * Drains the snoozes taken on the host side that no Dart isolate has
+   * observed yet.
+   *
+   * A snooze is normally taken with no engine running: the notification and
+   * the ringing screen are native, and a full screen intent starts the
+   * process without starting Flutter. [AlarmTriggerApi.alarmSnoozed] reaches
+   * nobody in that case, so the deferral is held until an isolate collects
+   * it. Draining is destructive; a collected snooze is not reported twice.
+   */
+  fun takeUnreportedSnoozes(callback: (Result<List<SnoozedAlarmWire>>) -> Unit)
 
   companion object {
     /** The codec used by AlarmApi. */
@@ -478,6 +551,24 @@ interface AlarmApi {
           channel.setMessageHandler(null)
         }
       }
+      run {
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.alarm.AlarmApi.takeUnreportedSnoozes$separatedMessageChannelSuffix", codec)
+        if (api != null) {
+          channel.setMessageHandler { _, reply ->
+            api.takeUnreportedSnoozes{ result: Result<List<SnoozedAlarmWire>> ->
+              val error = result.exceptionOrNull()
+              if (error != null) {
+                reply.reply(FlutterBindingsPigeonUtils.wrapError(error))
+              } else {
+                val data = result.getOrNull()
+                reply.reply(FlutterBindingsPigeonUtils.wrapResult(data))
+              }
+            }
+          }
+        } else {
+          channel.setMessageHandler(null)
+        }
+      }
     }
   }
 }
@@ -512,6 +603,31 @@ class AlarmTriggerApi(private val binaryMessenger: BinaryMessenger, private val 
     val channelName = "dev.flutter.pigeon.alarm.AlarmTriggerApi.alarmStopped$separatedMessageChannelSuffix"
     val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
     channel.send(listOf(alarmIdArg)) {
+      if (it is List<*>) {
+        if (it.size > 1) {
+          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+        } else {
+          callback(Result.success(Unit))
+        }
+      } else {
+        callback(Result.failure(FlutterBindingsPigeonUtils.createConnectionError(channelName)))
+      } 
+    }
+  }
+  /**
+   * An alarm was deferred on the host side and re-registered for
+   * [millisecondsSinceEpoch].
+   *
+   * Distinct from [alarmStopped] because the alarm is still owed: reporting a
+   * snooze as a stop would tell the application the user dismissed something
+   * they asked to be reminded of again.
+   */
+  fun alarmSnoozed(alarmIdArg: Long, millisecondsSinceEpochArg: Long, callback: (Result<Unit>) -> Unit)
+{
+    val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
+    val channelName = "dev.flutter.pigeon.alarm.AlarmTriggerApi.alarmSnoozed$separatedMessageChannelSuffix"
+    val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
+    channel.send(listOf(alarmIdArg, millisecondsSinceEpochArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
           callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))

--- a/android/src/main/kotlin/com/gdelataillade/alarm/generated/FlutterBindings.g.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/generated/FlutterBindings.g.kt
@@ -122,11 +122,14 @@ data class AlarmSettingsWire (
   val androidStopAlarmOnTermination: Boolean,
   val preferConnectedAudioDevice: Boolean,
   /**
-   * How long the snooze action defers the alarm, in seconds.
+   * How long the snooze action defers the alarm, in milliseconds.
    *
-   * Null, or anything below one, offers no snooze. Android only.
+   * Null, or anything below one minute, offers no snooze. The floor exists
+   * because Android scheduling falls back to a plain `Handler.postDelayed`
+   * below a few seconds, which survives neither process death nor
+   * cancellation. Android only.
    */
-  val androidSnoozeDurationSeconds: Long? = null
+  val androidSnoozeDurationMillis: Long? = null
 )
  {
   companion object {
@@ -145,8 +148,8 @@ data class AlarmSettingsWire (
       val iOSBackgroundAudio = pigeonVar_list[11] as Boolean
       val androidStopAlarmOnTermination = pigeonVar_list[12] as Boolean
       val preferConnectedAudioDevice = pigeonVar_list[13] as Boolean
-      val androidSnoozeDurationSeconds = pigeonVar_list[14] as Long?
-      return AlarmSettingsWire(id, millisecondsSinceEpoch, assetAudioPath, volumeSettings, notificationSettings, loopAudio, vibrate, warningNotificationOnKill, androidFullScreenIntent, allowAlarmOverlap, allowSameSecondScheduling, iOSBackgroundAudio, androidStopAlarmOnTermination, preferConnectedAudioDevice, androidSnoozeDurationSeconds)
+      val androidSnoozeDurationMillis = pigeonVar_list[14] as Long?
+      return AlarmSettingsWire(id, millisecondsSinceEpoch, assetAudioPath, volumeSettings, notificationSettings, loopAudio, vibrate, warningNotificationOnKill, androidFullScreenIntent, allowAlarmOverlap, allowSameSecondScheduling, iOSBackgroundAudio, androidStopAlarmOnTermination, preferConnectedAudioDevice, androidSnoozeDurationMillis)
     }
   }
   fun toList(): List<Any?> {
@@ -165,7 +168,7 @@ data class AlarmSettingsWire (
       iOSBackgroundAudio,
       androidStopAlarmOnTermination,
       preferConnectedAudioDevice,
-      androidSnoozeDurationSeconds,
+      androidSnoozeDurationMillis,
     )
   }
   override fun equals(other: Any?): Boolean {
@@ -265,9 +268,9 @@ data class NotificationSettingsWire (
   /**
    * Label for the snooze action. Null omits the action.
    *
-   * Only shown when [AlarmSettingsWire.androidSnoozeDurationSeconds] also
-   * gives it a duration; a label alone describes nothing the platform can
-   * perform. Android only.
+   * Only shown when [AlarmSettingsWire.androidSnoozeDurationMillis] also
+   * gives it a usable duration; a label alone describes nothing the platform
+   * can perform. Android only.
    */
   val snoozeButton: String? = null
 )
@@ -314,20 +317,20 @@ data class NotificationSettingsWire (
 }
 
 /**
- * One deferral taken on the host side.
+ * A snooze the host recorded and Dart has not yet applied.
  *
  * Generated class from Pigeon that represents data sent in messages.
  */
-data class SnoozedAlarmWire (
+data class PendingSnoozeWire (
   val alarmId: Long,
   val millisecondsSinceEpoch: Long
 )
  {
   companion object {
-    fun fromList(pigeonVar_list: List<Any?>): SnoozedAlarmWire {
+    fun fromList(pigeonVar_list: List<Any?>): PendingSnoozeWire {
       val alarmId = pigeonVar_list[0] as Long
       val millisecondsSinceEpoch = pigeonVar_list[1] as Long
-      return SnoozedAlarmWire(alarmId, millisecondsSinceEpoch)
+      return PendingSnoozeWire(alarmId, millisecondsSinceEpoch)
     }
   }
   fun toList(): List<Any?> {
@@ -337,7 +340,7 @@ data class SnoozedAlarmWire (
     )
   }
   override fun equals(other: Any?): Boolean {
-    if (other !is SnoozedAlarmWire) {
+    if (other !is PendingSnoozeWire) {
       return false
     }
     if (this === other) {
@@ -377,7 +380,7 @@ private open class FlutterBindingsPigeonCodec : StandardMessageCodec() {
       }
       134.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          SnoozedAlarmWire.fromList(it)
+          PendingSnoozeWire.fromList(it)
         }
       }
       else -> super.readValueOfType(type, buffer)
@@ -405,7 +408,7 @@ private open class FlutterBindingsPigeonCodec : StandardMessageCodec() {
         stream.write(133)
         writeValue(stream, value.toList())
       }
-      is SnoozedAlarmWire -> {
+      is PendingSnoozeWire -> {
         stream.write(134)
         writeValue(stream, value.toList())
       }
@@ -424,16 +427,27 @@ interface AlarmApi {
   fun setWarningNotificationOnKill(title: String, body: String)
   fun disableWarningNotificationOnKill()
   /**
-   * Drains the snoozes taken on the host side that no Dart isolate has
-   * observed yet.
+   * Lists snoozes the host has recorded but Dart has not yet applied.
    *
-   * A snooze is normally taken with no engine running: the notification and
-   * the ringing screen are native, and a full screen intent starts the
-   * process without starting Flutter. [AlarmTriggerApi.alarmSnoozed] reaches
-   * nobody in that case, so the deferral is held until an isolate collects
-   * it. Draining is destructive; a collected snooze is not reported twice.
+   * A snooze is normally taken with no engine running: the notification is
+   * native and a full screen intent starts the process without starting
+   * Flutter, so [AlarmTriggerApi.alarmSnoozed] reaches nobody. The host holds
+   * a marker until Dart has durably applied it.
+   *
+   * Reading is **not** destructive — the marker survives until
+   * [acknowledgeSnooze] confirms Dart wrote the new time. A read that is
+   * followed by a crash therefore loses nothing.
    */
-  fun takeUnreportedSnoozes(callback: (Result<List<SnoozedAlarmWire>>) -> Unit)
+  fun getPendingSnoozes(callback: (Result<List<PendingSnoozeWire>>) -> Unit)
+  /**
+   * Drops the marker for [alarmId], but only if it still records exactly
+   * [nextRingAtMillis].
+   *
+   * Matching on the timestamp as well as the id means a late acknowledgement
+   * for an earlier snooze cannot discard a newer one taken for the same
+   * alarm in the meantime.
+   */
+  fun acknowledgeSnooze(alarmId: Long, nextRingAtMillis: Long, callback: (Result<Unit>) -> Unit)
 
   companion object {
     /** The codec used by AlarmApi. */
@@ -552,16 +566,36 @@ interface AlarmApi {
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.alarm.AlarmApi.takeUnreportedSnoozes$separatedMessageChannelSuffix", codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.alarm.AlarmApi.getPendingSnoozes$separatedMessageChannelSuffix", codec)
         if (api != null) {
           channel.setMessageHandler { _, reply ->
-            api.takeUnreportedSnoozes{ result: Result<List<SnoozedAlarmWire>> ->
+            api.getPendingSnoozes{ result: Result<List<PendingSnoozeWire>> ->
               val error = result.exceptionOrNull()
               if (error != null) {
                 reply.reply(FlutterBindingsPigeonUtils.wrapError(error))
               } else {
                 val data = result.getOrNull()
                 reply.reply(FlutterBindingsPigeonUtils.wrapResult(data))
+              }
+            }
+          }
+        } else {
+          channel.setMessageHandler(null)
+        }
+      }
+      run {
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.alarm.AlarmApi.acknowledgeSnooze$separatedMessageChannelSuffix", codec)
+        if (api != null) {
+          channel.setMessageHandler { message, reply ->
+            val args = message as List<Any?>
+            val alarmIdArg = args[0] as Long
+            val nextRingAtMillisArg = args[1] as Long
+            api.acknowledgeSnooze(alarmIdArg, nextRingAtMillisArg) { result: Result<Unit> ->
+              val error = result.exceptionOrNull()
+              if (error != null) {
+                reply.reply(FlutterBindingsPigeonUtils.wrapError(error))
+              } else {
+                reply.reply(FlutterBindingsPigeonUtils.wrapResult(null))
               }
             }
           }

--- a/android/src/main/kotlin/com/gdelataillade/alarm/models/AlarmSettings.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/models/AlarmSettings.kt
@@ -30,7 +30,12 @@ data class AlarmSettings(
     val allowSameSecondScheduling: Boolean = false, // Defaults to false for backward compatibility
     val androidStopAlarmOnTermination: Boolean = true, // Defaults to true for backward compatibility
     val preferConnectedAudioDevice: Boolean = false, // Defaults to false for backward compatibility
+    val androidSnoozeDurationSeconds: Int? = null, // Null or below one offers no snooze
 ) {
+    /** Whether this alarm can be deferred rather than only stopped. */
+    val canSnooze: Boolean
+        get() = (androidSnoozeDurationSeconds ?: 0) >= 1
+
     companion object {
         fun fromWire(e: AlarmSettingsWire): AlarmSettings {
             return AlarmSettings(
@@ -47,6 +52,7 @@ data class AlarmSettings(
                 e.allowSameSecondScheduling,
                 e.androidStopAlarmOnTermination,
                 e.preferConnectedAudioDevice,
+                e.androidSnoozeDurationSeconds?.toInt(),
             )
         }
 
@@ -81,6 +87,10 @@ data class AlarmSettings(
             // Handle backward compatibility for `preferConnectedAudioDevice`
             val preferConnectedAudioDevice = jsonObject.primitiveBoolean("preferConnectedAudioDevice") ?: false
 
+            // Absent in alarms saved before snooze existed, which simply means
+            // the alarm can only be stopped.
+            val androidSnoozeDurationSeconds = jsonObject.primitiveInt("androidSnoozeDurationSeconds")
+
             // Handle backward compatibility for `volumeSettings`
             val volumeSettings = jsonObject["volumeSettings"]?.let {
                 Json.decodeFromJsonElement(VolumeSettings.serializer(), it)
@@ -113,6 +123,7 @@ data class AlarmSettings(
                 allowSameSecondScheduling = allowSameSecondScheduling,
                 androidStopAlarmOnTermination = androidStopAlarmOnTermination,
                 preferConnectedAudioDevice = preferConnectedAudioDevice,
+                androidSnoozeDurationSeconds = androidSnoozeDurationSeconds,
             )
         }
     }

--- a/android/src/main/kotlin/com/gdelataillade/alarm/models/AlarmSettings.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/models/AlarmSettings.kt
@@ -30,13 +30,24 @@ data class AlarmSettings(
     val allowSameSecondScheduling: Boolean = false, // Defaults to false for backward compatibility
     val androidStopAlarmOnTermination: Boolean = true, // Defaults to true for backward compatibility
     val preferConnectedAudioDevice: Boolean = false, // Defaults to false for backward compatibility
-    val androidSnoozeDurationSeconds: Int? = null, // Null or below one offers no snooze
+    // Null, or below SNOOZE_MINIMUM_MILLIS, offers no snooze.
+    val androidSnoozeDurationMillis: Long? = null,
 ) {
     /** Whether this alarm can be deferred rather than only stopped. */
     val canSnooze: Boolean
-        get() = (androidSnoozeDurationSeconds ?: 0) >= 1
+        get() = (androidSnoozeDurationMillis ?: 0L) >= SNOOZE_MINIMUM_MILLIS
 
     companion object {
+        /**
+         * Shortest snooze the platform accepts.
+         *
+         * Kept above the delay below which scheduling falls back to a plain
+         * `Handler.postDelayed` instead of `AlarmManager`: that fallback
+         * survives neither process death nor cancellation, so a snooze shorter
+         * than this could not be honoured or undone.
+         */
+        const val SNOOZE_MINIMUM_MILLIS = 60_000L
+
         fun fromWire(e: AlarmSettingsWire): AlarmSettings {
             return AlarmSettings(
                 e.id.toInt(),
@@ -52,7 +63,7 @@ data class AlarmSettings(
                 e.allowSameSecondScheduling,
                 e.androidStopAlarmOnTermination,
                 e.preferConnectedAudioDevice,
-                e.androidSnoozeDurationSeconds?.toInt(),
+                e.androidSnoozeDurationMillis,
             )
         }
 
@@ -89,7 +100,7 @@ data class AlarmSettings(
 
             // Absent in alarms saved before snooze existed, which simply means
             // the alarm can only be stopped.
-            val androidSnoozeDurationSeconds = jsonObject.primitiveInt("androidSnoozeDurationSeconds")
+            val androidSnoozeDurationMillis = jsonObject.primitiveLong("androidSnoozeDurationMillis")
 
             // Handle backward compatibility for `volumeSettings`
             val volumeSettings = jsonObject["volumeSettings"]?.let {
@@ -123,7 +134,7 @@ data class AlarmSettings(
                 allowSameSecondScheduling = allowSameSecondScheduling,
                 androidStopAlarmOnTermination = androidStopAlarmOnTermination,
                 preferConnectedAudioDevice = preferConnectedAudioDevice,
-                androidSnoozeDurationSeconds = androidSnoozeDurationSeconds,
+                androidSnoozeDurationMillis = androidSnoozeDurationMillis,
             )
         }
     }

--- a/android/src/main/kotlin/com/gdelataillade/alarm/models/NotificationSettings.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/models/NotificationSettings.kt
@@ -12,6 +12,7 @@ data class NotificationSettings(
     val icon: String? = null,
     val iconColor: Int? = null,
     val keepNotificationAfterAlarmEnds: Boolean = false,
+    val snoozeButton: String? = null,
 ) {
     companion object {
         fun fromWire(e: NotificationSettingsWire): NotificationSettings {
@@ -32,6 +33,7 @@ data class NotificationSettings(
                 e.icon,
                 iconColor,
                 e.keepNotificationAfterAlarmEnds,
+                e.snoozeButton,
             )
         }
     }

--- a/android/src/main/kotlin/com/gdelataillade/alarm/models/NotificationSettings.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/models/NotificationSettings.kt
@@ -12,7 +12,7 @@ data class NotificationSettings(
     val icon: String? = null,
     val iconColor: Int? = null,
     val keepNotificationAfterAlarmEnds: Boolean = false,
-    val snoozeButton: String? = null,
+    val androidSnoozeButton: String? = null,
 ) {
     companion object {
         fun fromWire(e: NotificationSettingsWire): NotificationSettings {
@@ -33,7 +33,7 @@ data class NotificationSettings(
                 e.icon,
                 iconColor,
                 e.keepNotificationAfterAlarmEnds,
-                e.snoozeButton,
+                e.androidSnoozeButton,
             )
         }
     }

--- a/android/src/main/kotlin/com/gdelataillade/alarm/services/AlarmScheduler.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/services/AlarmScheduler.kt
@@ -1,0 +1,173 @@
+package com.gdelataillade.alarm.services
+
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.os.Handler
+import android.os.Looper
+import com.gdelataillade.alarm.alarm.AlarmReceiver
+import com.gdelataillade.alarm.models.AlarmSettings
+import io.flutter.Log
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+/**
+ * Persists an alarm and arms the platform to deliver it.
+ *
+ * Deliberately context-only and free of any stop path: it never touches
+ * `AlarmApiImpl.alarmIds`, never calls `AlarmApiImpl.stopAlarm`,
+ * `AlarmService.handleStopAlarmCommand` or `AlarmService.unsaveAlarm`, and never
+ * reports anything to Flutter. Those all announce a *stop*, which is exactly
+ * wrong for a snooze — the alarm is still owed. Callers that do want the
+ * replace-then-reschedule behaviour layer it on top themselves.
+ */
+object AlarmScheduler {
+    private const val TAG = "AlarmScheduler"
+
+    /**
+     * Delay at or below which the platform is armed with a plain
+     * `Handler.postDelayed` instead of `AlarmManager`.
+     *
+     * That fallback lives only as long as the process and cannot be cancelled
+     * through `AlarmManager.cancel`, so it is unusable for anything that has to
+     * survive termination.
+     */
+    const val IMMEDIATE_THRESHOLD_MILLIS = 5000L
+
+    /**
+     * Saves [alarm] and arms its delivery.
+     *
+     * When [requireDurable] is set, refuses rather than falling back to the
+     * in-process timer, so a caller that needs the alarm to survive process
+     * death finds out instead of silently getting a weaker guarantee.
+     *
+     * Returns whether the alarm is now both stored and armed. An exact-alarm
+     * permission downgrade to an inexact alarm still counts as success: the
+     * alarm may ring late, but it will ring.
+     */
+    fun schedule(
+        context: Context,
+        alarm: AlarmSettings,
+        requireDurable: Boolean = false,
+    ): Boolean {
+        val delayInMillis = alarm.dateTime.time - System.currentTimeMillis()
+
+        if (delayInMillis <= IMMEDIATE_THRESHOLD_MILLIS && requireDurable) {
+            Log.e(
+                TAG,
+                "Refusing to schedule alarm ${alarm.id} durably: it is due in " +
+                    "${delayInMillis}ms, which is below the ${IMMEDIATE_THRESHOLD_MILLIS}ms " +
+                    "AlarmManager threshold."
+            )
+            return false
+        }
+
+        AlarmStorage(context).saveAlarm(alarm)
+
+        val intent = Intent(context, AlarmReceiver::class.java).apply {
+            putExtra("id", alarm.id)
+            putExtra("alarmSettings", Json.encodeToString(alarm))
+        }
+
+        return if (delayInMillis <= IMMEDIATE_THRESHOLD_MILLIS) {
+            Handler(Looper.getMainLooper()).postDelayed(
+                { context.sendBroadcast(intent) },
+                delayInMillis.coerceAtLeast(0L)
+            )
+            true
+        } else {
+            armAlarmManager(context, intent, alarm.dateTime.time, alarm.id)
+        }
+    }
+
+    /**
+     * Arms `AlarmManager` for [triggerTimeMillis].
+     *
+     * Unlike the code this replaced, a genuine failure is reported rather than
+     * logged and swallowed — a caller that has silenced a ringing alarm on the
+     * strength of a successful reschedule has to be able to tell.
+     */
+    private fun armAlarmManager(
+        context: Context,
+        intent: Intent,
+        triggerTimeMillis: Long,
+        id: Int,
+    ): Boolean {
+        return try {
+            val pendingIntent = PendingIntent.getBroadcast(
+                context,
+                id,
+                intent,
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+            )
+
+            val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as? AlarmManager
+                ?: throw IllegalStateException("AlarmManager not available")
+
+            setExactAlarm(alarmManager, triggerTimeMillis, pendingIntent)
+            true
+        } catch (e: ClassCastException) {
+            Log.e(TAG, "AlarmManager service type casting failed", e)
+            false
+        } catch (e: IllegalStateException) {
+            Log.e(TAG, "AlarmManager service not available", e)
+            false
+        } catch (e: Exception) {
+            Log.e(TAG, "Error while arming alarm $id", e)
+            false
+        }
+    }
+
+    private fun setExactAlarm(
+        alarmManager: AlarmManager,
+        triggerTimeMillis: Long,
+        pendingIntent: PendingIntent,
+    ) {
+        // On Android 12+ the user can revoke the exact alarm permission at any
+        // time. Fall back to an inexact alarm instead of silently scheduling
+        // nothing: the alarm may ring a few minutes late, but it will ring.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
+            !alarmManager.canScheduleExactAlarms()
+        ) {
+            Log.w(
+                TAG,
+                "SCHEDULE_EXACT_ALARM permission not granted. Falling back to an " +
+                    "inexact alarm, which may ring late. Ask the user to grant the " +
+                    "'Alarms & reminders' permission for exact scheduling."
+            )
+            alarmManager.setAndAllowWhileIdle(
+                AlarmManager.RTC_WAKEUP,
+                triggerTimeMillis,
+                pendingIntent
+            )
+            return
+        }
+
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                alarmManager.setExactAndAllowWhileIdle(
+                    AlarmManager.RTC_WAKEUP,
+                    triggerTimeMillis,
+                    pendingIntent
+                )
+            } else {
+                alarmManager.setExact(AlarmManager.RTC_WAKEUP, triggerTimeMillis, pendingIntent)
+            }
+        } catch (e: SecurityException) {
+            // Defensive: the permission state changed between the check above
+            // and the call, or an OEM enforces it on older API levels.
+            Log.e(TAG, "Exact alarm scheduling rejected; falling back to inexact alarm", e)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                alarmManager.setAndAllowWhileIdle(
+                    AlarmManager.RTC_WAKEUP,
+                    triggerTimeMillis,
+                    pendingIntent
+                )
+            } else {
+                alarmManager.set(AlarmManager.RTC_WAKEUP, triggerTimeMillis, pendingIntent)
+            }
+        }
+    }
+}

--- a/android/src/main/kotlin/com/gdelataillade/alarm/services/AlarmScheduler.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/services/AlarmScheduler.kt
@@ -71,7 +71,7 @@ object AlarmScheduler {
             putExtra("alarmSettings", Json.encodeToString(alarm))
         }
 
-        return if (delayInMillis <= IMMEDIATE_THRESHOLD_MILLIS) {
+        val armed = if (delayInMillis <= IMMEDIATE_THRESHOLD_MILLIS) {
             Handler(Looper.getMainLooper()).postDelayed(
                 { context.sendBroadcast(intent) },
                 delayInMillis.coerceAtLeast(0L)
@@ -80,6 +80,13 @@ object AlarmScheduler {
         } else {
             armAlarmManager(context, intent, alarm.dateTime.time, alarm.id)
         }
+
+        // Every path that adds a pending alarm has to leave the kill warning
+        // consistent with it, including the snooze path, which reaches here
+        // without going through the plugin.
+        WarningNotificationState.refresh(context)
+
+        return armed
     }
 
     /**

--- a/android/src/main/kotlin/com/gdelataillade/alarm/services/AlarmStorage.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/services/AlarmStorage.kt
@@ -25,6 +25,10 @@ class AlarmStorage(context: Context) {
         private const val TAG = "AlarmStorage"
         private const val PREFIX = "__alarm_id__"
         private const val SNOOZE_PREFIX = "__snoozed_alarm_id__"
+
+        // How long past its ring time a marker Dart never applied is kept
+        // before being discarded as unapplicable.
+        private const val SNOOZE_MARKER_TTL_MILLIS = 7L * 24 * 60 * 60 * 1000
     }
 
     private val dataStore = context.dataStore
@@ -95,30 +99,72 @@ class AlarmStorage(context: Context) {
         }
     }
 
-    /** Reads and clears every unreported snooze, keyed by alarm id. */
-    fun takeSnoozes(): Map<Int, Long> {
+    /**
+     * Reads every pending snooze marker, keyed by alarm id.
+     *
+     * Non-destructive on purpose: a marker survives until [acknowledgeSnooze]
+     * confirms Dart durably applied it, so a read followed by a crash loses
+     * nothing. Markers older than [SNOOZE_MARKER_TTL_MILLIS] are dropped, so a
+     * marker Dart can never apply cannot accumulate forever.
+     */
+    fun getPendingSnoozes(): Map<Int, Long> {
         return runBlocking {
             val stored = dataStore.data.map { prefs ->
                 prefs.asMap().filterKeys { it.name.startsWith(SNOOZE_PREFIX) }
             }.first()
 
             val snoozes = mutableMapOf<Int, Long>()
+            val expired = mutableListOf<Preferences.Key<*>>()
+            val now = System.currentTimeMillis()
             stored.forEach { (key, value) ->
                 val id = key.name.removePrefix(SNOOZE_PREFIX).toIntOrNull()
                 val nextRingAt = (value as? String)?.toLongOrNull()
                 if (id == null || nextRingAt == null) {
-                    Log.w(TAG, "Skipping unreadable snooze with key: ${key.name}")
+                    Log.w(TAG, "Dropping unreadable snooze marker: ${key.name}")
+                    expired.add(key)
+                } else if (now - nextRingAt > SNOOZE_MARKER_TTL_MILLIS) {
+                    Log.w(TAG, "Dropping snooze marker for $id, stale since $nextRingAt.")
+                    expired.add(key)
                 } else {
                     snoozes[id] = nextRingAt
                 }
             }
 
-            if (stored.isNotEmpty()) {
+            if (expired.isNotEmpty()) {
                 dataStore.edit { preferences ->
-                    stored.keys.forEach { preferences.remove(it) }
+                    expired.forEach { preferences.remove(it) }
                 }
             }
             snoozes
+        }
+    }
+
+    /**
+     * Drops the marker for [id], but only if it still records exactly
+     * [nextRingAtMillis].
+     *
+     * Comparing the timestamp as well as the id means a late acknowledgement
+     * for an earlier snooze cannot discard a newer one taken for the same alarm
+     * in the meantime.
+     */
+    fun acknowledgeSnooze(id: Int, nextRingAtMillis: Long) {
+        return runBlocking {
+            val key = stringPreferencesKey("$SNOOZE_PREFIX$id")
+            dataStore.edit { preferences ->
+                if (preferences[key] == nextRingAtMillis.toString()) {
+                    preferences.remove(key)
+                } else {
+                    Log.d(TAG, "Not acknowledging snooze $id: marker moved on.")
+                }
+            }
+        }
+    }
+
+    /** Removes any pending snooze marker for [id], whatever it records. */
+    fun clearSnooze(id: Int) {
+        return runBlocking {
+            val key = stringPreferencesKey("$SNOOZE_PREFIX$id")
+            dataStore.edit { preferences -> preferences.remove(key) }
         }
     }
 }

--- a/android/src/main/kotlin/com/gdelataillade/alarm/services/AlarmStorage.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/services/AlarmStorage.kt
@@ -29,6 +29,9 @@ class AlarmStorage(context: Context) {
         // How long past its ring time a marker Dart never applied is kept
         // before being discarded as unapplicable.
         private const val SNOOZE_MARKER_TTL_MILLIS = 7L * 24 * 60 * 60 * 1000
+
+        private const val WARNING_TITLE_KEY = "notificationOnAppKillTitle"
+        private const val WARNING_BODY_KEY = "notificationOnAppKillBody"
     }
 
     private val dataStore = context.dataStore
@@ -164,6 +167,32 @@ class AlarmStorage(context: Context) {
                     Log.d(TAG, "Not acknowledging snooze $id: marker moved on.")
                 }
             }
+        }
+    }
+
+    /**
+     * Persists the kill-warning notification text.
+     *
+     * Held here rather than in memory because the context that has to show the
+     * warning is often not the one that was told what it should say — a snooze
+     * taken from a notification runs with no engine and no plugin instance.
+     */
+    fun saveWarningNotificationText(title: String, body: String) {
+        return runBlocking {
+            dataStore.edit { preferences ->
+                preferences[stringPreferencesKey(WARNING_TITLE_KEY)] = title
+                preferences[stringPreferencesKey(WARNING_BODY_KEY)] = body
+            }
+        }
+    }
+
+    /** The stored kill-warning text, or null when the app never set any. */
+    fun getWarningNotificationText(): Pair<String, String>? {
+        return runBlocking {
+            val prefs = dataStore.data.first()
+            val title = prefs[stringPreferencesKey(WARNING_TITLE_KEY)]
+            val body = prefs[stringPreferencesKey(WARNING_BODY_KEY)]
+            if (title == null || body == null) null else title to body
         }
     }
 

--- a/android/src/main/kotlin/com/gdelataillade/alarm/services/AlarmStorage.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/services/AlarmStorage.kt
@@ -44,7 +44,14 @@ class AlarmStorage(context: Context) {
     fun unsaveAlarm(id: Int) {
         return runBlocking {
             val key = stringPreferencesKey("$PREFIX$id")
-            dataStore.edit { preferences -> preferences.remove(key) }
+            val snoozeKey = stringPreferencesKey("$SNOOZE_PREFIX$id")
+            dataStore.edit { preferences ->
+                preferences.remove(key)
+                // A stopped alarm is no longer owed, so any pending deferral for
+                // it is moot. Left behind, the marker would reappear on the next
+                // Alarm.init() and try to resurrect an alarm the user dismissed.
+                preferences.remove(snoozeKey)
+            }
         }
     }
 

--- a/android/src/main/kotlin/com/gdelataillade/alarm/services/AlarmStorage.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/services/AlarmStorage.kt
@@ -24,6 +24,7 @@ class AlarmStorage(context: Context) {
     companion object {
         private const val TAG = "AlarmStorage"
         private const val PREFIX = "__alarm_id__"
+        private const val SNOOZE_PREFIX = "__snoozed_alarm_id__"
     }
 
     private val dataStore = context.dataStore
@@ -74,6 +75,50 @@ class AlarmStorage(context: Context) {
                 }
             }
             alarms
+        }
+    }
+
+    /**
+     * Records that [id] was deferred until [nextRingAtMillis].
+     *
+     * A snooze is normally taken with no Flutter engine running, because the
+     * notification and the ringing screen are native. Holding the deferral
+     * here is what lets the next isolate learn about it instead of finding an
+     * alarm that silently moved.
+     */
+    fun saveSnooze(id: Int, nextRingAtMillis: Long) {
+        return runBlocking {
+            val key = stringPreferencesKey("$SNOOZE_PREFIX$id")
+            dataStore.edit { preferences ->
+                preferences[key] = nextRingAtMillis.toString()
+            }
+        }
+    }
+
+    /** Reads and clears every unreported snooze, keyed by alarm id. */
+    fun takeSnoozes(): Map<Int, Long> {
+        return runBlocking {
+            val stored = dataStore.data.map { prefs ->
+                prefs.asMap().filterKeys { it.name.startsWith(SNOOZE_PREFIX) }
+            }.first()
+
+            val snoozes = mutableMapOf<Int, Long>()
+            stored.forEach { (key, value) ->
+                val id = key.name.removePrefix(SNOOZE_PREFIX).toIntOrNull()
+                val nextRingAt = (value as? String)?.toLongOrNull()
+                if (id == null || nextRingAt == null) {
+                    Log.w(TAG, "Skipping unreadable snooze with key: ${key.name}")
+                } else {
+                    snoozes[id] = nextRingAt
+                }
+            }
+
+            if (stored.isNotEmpty()) {
+                dataStore.edit { preferences ->
+                    stored.keys.forEach { preferences.remove(it) }
+                }
+            }
+            snoozes
         }
     }
 }

--- a/android/src/main/kotlin/com/gdelataillade/alarm/services/NotificationService.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/services/NotificationService.kt
@@ -52,7 +52,8 @@ class NotificationHandler(private val context: Context) {
         notificationSettings: NotificationSettings,
         fullScreen: Boolean,
         pendingIntent: PendingIntent,
-        alarmId: Int
+        alarmId: Int,
+        canSnooze: Boolean = false
     ): Notification {
         val defaultIconResId =
             context.packageManager.getApplicationInfo(context.packageName, 0).icon
@@ -102,6 +103,22 @@ class NotificationHandler(private val context: Context) {
         notificationSettings.let {
             if (it.stopButton != null) {
                 notificationBuilder.addAction(0, it.stopButton, stopPendingIntent)
+            }
+
+            // A label without a duration describes an action the platform
+            // cannot perform, so both are required before it is offered.
+            if (it.snoozeButton != null && canSnooze) {
+                val snoozeIntent = Intent(context, AlarmReceiver::class.java).apply {
+                    action = AlarmReceiver.ACTION_ALARM_SNOOZE
+                    putExtra("id", alarmId)
+                }
+                val snoozePendingIntent = PendingIntent.getBroadcast(
+                    context,
+                    alarmId,
+                    snoozeIntent,
+                    PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+                )
+                notificationBuilder.addAction(0, it.snoozeButton, snoozePendingIntent)
             }
 
             if (it.iconColor != null) {

--- a/android/src/main/kotlin/com/gdelataillade/alarm/services/NotificationService.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/services/NotificationService.kt
@@ -107,7 +107,7 @@ class NotificationHandler(private val context: Context) {
 
             // A label without a duration describes an action the platform
             // cannot perform, so both are required before it is offered.
-            if (it.snoozeButton != null && canSnooze) {
+            if (it.androidSnoozeButton != null && canSnooze) {
                 val snoozeIntent = Intent(context, AlarmReceiver::class.java).apply {
                     action = AlarmReceiver.ACTION_ALARM_SNOOZE
                     putExtra("id", alarmId)
@@ -118,7 +118,7 @@ class NotificationHandler(private val context: Context) {
                     snoozeIntent,
                     PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
                 )
-                notificationBuilder.addAction(0, it.snoozeButton, snoozePendingIntent)
+                notificationBuilder.addAction(0, it.androidSnoozeButton, snoozePendingIntent)
             }
 
             if (it.iconColor != null) {

--- a/android/src/main/kotlin/com/gdelataillade/alarm/services/SnoozeCoordinator.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/services/SnoozeCoordinator.kt
@@ -1,0 +1,94 @@
+package com.gdelataillade.alarm.services
+
+import android.content.Context
+import com.gdelataillade.alarm.alarm.AlarmPlugin
+import com.gdelataillade.alarm.alarm.AlarmService
+import com.gdelataillade.alarm.models.AlarmSettings
+import io.flutter.Log
+import java.util.Date
+
+/**
+ * Defers a ringing alarm instead of dismissing it.
+ *
+ * Lives outside [AlarmService] because the snooze action is normally pressed
+ * with no Flutter engine and sometimes with no service either: the notification
+ * is native, and the service can have been killed while its notification
+ * lingered. Both entry points — the running service and [AlarmReceiver] — call
+ * this same code so a snooze cannot quietly become a no-op.
+ */
+object SnoozeCoordinator {
+    private const val TAG = "SnoozeCoordinator"
+
+    /**
+     * Defers [alarmId] by its own snooze duration.
+     *
+     * Ordering matters. The replacement is scheduled *before* the current ring
+     * is silenced, so a failure to reschedule leaves the alarm audibly ringing
+     * rather than silently cancelled — the user still gets their alarm, which
+     * is the whole point of the feature.
+     *
+     * Returns whether the alarm was deferred.
+     */
+    fun snooze(context: Context, alarmId: Int): Boolean {
+        if (alarmId == 0) return false
+
+        val storage = AlarmStorage(context)
+        val settings = storage.getSavedAlarms().firstOrNull { it.id == alarmId }
+        if (settings == null) {
+            Log.w(TAG, "Cannot snooze $alarmId: no stored alarm with that id.")
+            return false
+        }
+
+        val durationMillis = settings.androidSnoozeDurationMillis
+        if (!settings.canSnooze || durationMillis == null) {
+            // Defensive: the action is only added to the notification when the
+            // alarm can snooze. Leave it ringing rather than dismissing
+            // something the user did not ask to dismiss.
+            Log.w(TAG, "Cannot snooze $alarmId: no usable snooze duration.")
+            return false
+        }
+
+        val nextRingAt = System.currentTimeMillis() + durationMillis
+        val deferred = settings.copy(dateTime = Date(nextRingAt))
+
+        // Written before scheduling so a crash mid-way still leaves Dart able to
+        // learn the alarm moved. Without it, Dart's own store keeps the original
+        // past time and its next reconciliation pass would stop the alarm.
+        storage.saveSnooze(alarmId, nextRingAt)
+
+        val scheduled = AlarmScheduler.schedule(context, deferred, requireDurable = true)
+        if (!scheduled) {
+            Log.e(TAG, "Failed to reschedule $alarmId; leaving it ringing.")
+            // Undo both halves: the scheduler may already have persisted the
+            // deferred time, and the marker now describes a snooze that is not
+            // actually armed.
+            storage.saveAlarm(settings)
+            storage.clearSnooze(alarmId)
+            return false
+        }
+
+        // Only now is it safe to go quiet.
+        val service = AlarmService.instance
+        if (service != null) {
+            service.silenceForSnooze(alarmId)
+        } else {
+            // No foreground service owns the notification, so it has to be
+            // dismissed explicitly or it lingers over a snoozed alarm.
+            NotificationHandler(context).cancelNotification(alarmId)
+        }
+
+        AlarmPlugin.alarmTriggerApi?.alarmSnoozed(alarmId.toLong(), nextRingAt) { result ->
+            if (result.isSuccess) {
+                // Dart has durably applied it, so the marker has done its job.
+                // Matching on the timestamp means this cannot drop a newer
+                // snooze taken for the same alarm in the meantime.
+                storage.acknowledgeSnooze(alarmId, nextRingAt)
+            } else {
+                Log.d(TAG, "Dart did not apply the snooze for $alarmId; keeping the marker.")
+            }
+        }
+
+        Log.d(TAG, "Alarm $alarmId snoozed until $nextRingAt.")
+        return true
+    }
+}

--- a/android/src/main/kotlin/com/gdelataillade/alarm/services/SnoozeCoordinator.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/services/SnoozeCoordinator.kt
@@ -40,11 +40,17 @@ object SnoozeCoordinator {
         }
 
         val durationMillis = settings.androidSnoozeDurationMillis
-        if (!settings.canSnooze || durationMillis == null) {
-            // Defensive: the action is only added to the notification when the
-            // alarm can snooze. Leave it ringing rather than dismissing
-            // something the user did not ask to dismiss.
-            Log.w(TAG, "Cannot snooze $alarmId: no usable snooze duration.")
+        // Both halves are required, matching the notification action and the
+        // ring-activity label: an alarm that never offered snooze anywhere must
+        // not be deferrable by broadcasting the action directly. AlarmReceiver
+        // is exported, so this is the only thing enforcing that.
+        if (!settings.canSnooze ||
+            durationMillis == null ||
+            settings.notificationSettings.androidSnoozeButton == null
+        ) {
+            // Leave it ringing rather than dismissing something the user did
+            // not ask to dismiss.
+            Log.w(TAG, "Cannot snooze $alarmId: snooze is not configured for it.")
             return false
         }
 

--- a/android/src/main/kotlin/com/gdelataillade/alarm/services/WarningNotificationState.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/services/WarningNotificationState.kt
@@ -1,0 +1,67 @@
+package com.gdelataillade.alarm.services
+
+import android.content.Context
+import android.content.Intent
+import io.flutter.Log
+
+/**
+ * Keeps [NotificationOnKillService] in step with the stored alarms.
+ *
+ * The invariant is simply: the warning runs when at least one stored alarm asked
+ * for it. Enforcing that from one place matters because the alarm set changes
+ * from contexts that have no Flutter engine — a snooze taken from a notification
+ * reschedules an alarm, and previously nothing re-armed the warning afterwards,
+ * so killing the app during a snooze produced no warning at all.
+ *
+ * The title and body are persisted rather than held in memory for the same
+ * reason: the process that needs them is often not the one that was told them.
+ */
+object WarningNotificationState {
+    private const val TAG = "WarningNotificationState"
+
+    private const val DEFAULT_TITLE = "Your alarms may not ring"
+    private const val DEFAULT_BODY =
+        "You killed the app. Please reopen so your alarms can be rescheduled."
+
+    /** Records the text to show, so any later context can reproduce it. */
+    fun setText(context: Context, title: String, body: String) {
+        AlarmStorage(context).saveWarningNotificationText(title, body)
+    }
+
+    /** Starts or stops the warning to match the currently stored alarms. */
+    fun refresh(context: Context) {
+        val storage = AlarmStorage(context)
+        val wanted = storage.getSavedAlarms().any { it.warningNotificationOnKill }
+        if (wanted) turnOn(context, storage) else turnOff(context)
+    }
+
+    /** Stops the warning regardless of what the stored alarms ask for. */
+    fun disable(context: Context) = turnOff(context)
+
+    private fun turnOn(context: Context, storage: AlarmStorage) {
+        if (NotificationOnKillService.isRunning) {
+            Log.d(TAG, "Warning notification is already turned on.")
+            return
+        }
+
+        val (title, body) = storage.getWarningNotificationText()
+            ?: (DEFAULT_TITLE to DEFAULT_BODY)
+
+        val serviceIntent = Intent(context, NotificationOnKillService::class.java)
+        serviceIntent.putExtra("title", title)
+        serviceIntent.putExtra("body", body)
+
+        context.startService(serviceIntent)
+        Log.d(TAG, "Warning notification turned on.")
+    }
+
+    private fun turnOff(context: Context) {
+        if (!NotificationOnKillService.isRunning) {
+            Log.d(TAG, "Warning notification is already turned off.")
+            return
+        }
+
+        context.stopService(Intent(context, NotificationOnKillService::class.java))
+        Log.d(TAG, "Warning notification turned off.")
+    }
+}

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -12,7 +12,20 @@ Future<void> main() async {
 
   setupLogging(showDebugLogs: true);
 
+  // Subscribed before Alarm.init() on purpose. A snooze taken while the app was
+  // not running is replayed during init, and Alarm.snoozed is a plain broadcast
+  // stream, so a listener registered afterwards -- from a widget, say -- would
+  // miss it entirely.
+  final replayedSnoozes = <({int id, DateTime nextRingAt})>[];
+  final snoozeSubscription = Alarm.snoozed.listen(replayedSnoozes.add);
+
   await Alarm.init();
+
+  for (final snooze in replayedSnoozes) {
+    debugPrint('Replayed snooze: alarm ${snooze.id} rings at '
+        '${snooze.nextRingAt}');
+  }
+  await snoozeSubscription.cancel();
 
   runApp(
     MaterialApp(

--- a/example/lib/screens/edit_alarm.dart
+++ b/example/lib/screens/edit_alarm.dart
@@ -121,10 +121,14 @@ class _ExampleAlarmEditScreenState extends State<ExampleAlarmEditScreen> {
       assetAudioPath: assetAudio,
       volumeSettings: volumeSettings,
       allowAlarmOverlap: true,
+      // Android only. Needs the matching androidSnoozeButton label below to
+      // show up, and must be at least AlarmSettings.minSnoozeDuration.
+      androidSnoozeDuration: const Duration(minutes: 1),
       notificationSettings: NotificationSettings(
         title: 'Alarm example',
         body: 'Your alarm ($id) is ringing',
         stopButton: 'Stop the alarm',
+        androidSnoozeButton: 'Snooze',
         icon: 'notification_icon',
         keepNotificationAfterAlarmEnds: true,
       ),

--- a/example/lib/screens/home.dart
+++ b/example/lib/screens/home.dart
@@ -26,6 +26,7 @@ class _ExampleAlarmHomeScreenState extends State<ExampleAlarmHomeScreen> {
 
   StreamSubscription<AlarmSet>? ringSubscription;
   StreamSubscription<AlarmSet>? updateSubscription;
+  StreamSubscription<({int id, DateTime nextRingAt})>? snoozeSubscription;
 
   @override
   void initState() {
@@ -38,7 +39,23 @@ class _ExampleAlarmHomeScreenState extends State<ExampleAlarmHomeScreen> {
     updateSubscription = Alarm.scheduled.listen((_) {
       unawaited(loadAlarms());
     });
+    // Android only. A snooze taken from the notification arrives here, and
+    // also arrives on the next Alarm.init() if it was taken while the app was
+    // not running.
+    snoozeSubscription = Alarm.snoozed.listen(snoozed);
     notifications = Notifications();
+  }
+
+  void snoozed(({int id, DateTime nextRingAt}) snooze) {
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(
+          'Alarm ${snooze.id} snoozed until '
+          '${TimeOfDay.fromDateTime(snooze.nextRingAt).format(context)}',
+        ),
+      ),
+    );
   }
 
   Future<void> loadAlarms() async {
@@ -90,6 +107,7 @@ class _ExampleAlarmHomeScreenState extends State<ExampleAlarmHomeScreen> {
   void dispose() {
     ringSubscription?.cancel();
     updateSubscription?.cancel();
+    snoozeSubscription?.cancel();
     super.dispose();
   }
 

--- a/example/lib/screens/home.dart
+++ b/example/lib/screens/home.dart
@@ -39,9 +39,11 @@ class _ExampleAlarmHomeScreenState extends State<ExampleAlarmHomeScreen> {
     updateSubscription = Alarm.scheduled.listen((_) {
       unawaited(loadAlarms());
     });
-    // Android only. A snooze taken from the notification arrives here, and
-    // also arrives on the next Alarm.init() if it was taken while the app was
-    // not running.
+    // Android only. This receives snoozes taken while the app is running.
+    // A snooze taken with no engine is replayed during Alarm.init(), which
+    // happens before this widget exists -- see main() for that half. Either
+    // way the alarm list below refreshes, because Alarm.scheduled replays its
+    // latest value to new listeners.
     snoozeSubscription = Alarm.snoozed.listen(snoozed);
     notifications = Notifications();
   }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "5.6.0"
+    version: "5.7.0"
   args:
     dependency: transitive
     description:

--- a/ios/alarm/Sources/alarm/api/AlarmApiImpl.swift
+++ b/ios/alarm/Sources/alarm/api/AlarmApiImpl.swift
@@ -55,12 +55,21 @@ public class AlarmApiImpl: NSObject, AlarmApi {
             details: nil)
     }
 
-    /// Snoozing is an Android-only capability, so there is never anything
-    /// unreported here.
-    func takeUnreportedSnoozes(
-        completion: @escaping (Result<[SnoozedAlarmWire], Error>) -> Void
+    /// Snoozing is an Android-only capability, so there is never a marker here.
+    func getPendingSnoozes(
+        completion: @escaping (Result<[PendingSnoozeWire], Error>) -> Void
     ) {
         completion(.success([]))
+    }
+
+    /// No markers exist on iOS, so acknowledging one is a no-op rather than an
+    /// error: Dart calls this unconditionally after applying a snooze.
+    func acknowledgeSnooze(
+        alarmId: Int64,
+        nextRingAtMillis: Int64,
+        completion: @escaping (Result<Void, Error>) -> Void
+    ) {
+        completion(.success(()))
     }
 
     @MainActor

--- a/ios/alarm/Sources/alarm/api/AlarmApiImpl.swift
+++ b/ios/alarm/Sources/alarm/api/AlarmApiImpl.swift
@@ -55,6 +55,14 @@ public class AlarmApiImpl: NSObject, AlarmApi {
             details: nil)
     }
 
+    /// Snoozing is an Android-only capability, so there is never anything
+    /// unreported here.
+    func takeUnreportedSnoozes(
+        completion: @escaping (Result<[SnoozedAlarmWire], Error>) -> Void
+    ) {
+        completion(.success([]))
+    }
+
     @MainActor
     func appRefresh() async {
         BackgroundAudioManager.shared.refresh(registrar: self.registrar)

--- a/ios/alarm/Sources/alarm/generated/FlutterBindings.g.swift
+++ b/ios/alarm/Sources/alarm/generated/FlutterBindings.g.swift
@@ -164,6 +164,10 @@ struct AlarmSettingsWire: Hashable {
   var iOSBackgroundAudio: Bool
   var androidStopAlarmOnTermination: Bool
   var preferConnectedAudioDevice: Bool
+  /// How long the snooze action defers the alarm, in seconds.
+  ///
+  /// Null, or anything below one, offers no snooze. Android only.
+  var androidSnoozeDurationSeconds: Int64? = nil
 
 
   // swift-format-ignore: AlwaysUseLowerCamelCase
@@ -182,6 +186,7 @@ struct AlarmSettingsWire: Hashable {
     let iOSBackgroundAudio = pigeonVar_list[11] as! Bool
     let androidStopAlarmOnTermination = pigeonVar_list[12] as! Bool
     let preferConnectedAudioDevice = pigeonVar_list[13] as! Bool
+    let androidSnoozeDurationSeconds: Int64? = nilOrValue(pigeonVar_list[14])
 
     return AlarmSettingsWire(
       id: id,
@@ -197,7 +202,8 @@ struct AlarmSettingsWire: Hashable {
       allowSameSecondScheduling: allowSameSecondScheduling,
       iOSBackgroundAudio: iOSBackgroundAudio,
       androidStopAlarmOnTermination: androidStopAlarmOnTermination,
-      preferConnectedAudioDevice: preferConnectedAudioDevice
+      preferConnectedAudioDevice: preferConnectedAudioDevice,
+      androidSnoozeDurationSeconds: androidSnoozeDurationSeconds
     )
   }
   func toList() -> [Any?] {
@@ -216,6 +222,7 @@ struct AlarmSettingsWire: Hashable {
       iOSBackgroundAudio,
       androidStopAlarmOnTermination,
       preferConnectedAudioDevice,
+      androidSnoozeDurationSeconds,
     ]
   }
   static func == (lhs: AlarmSettingsWire, rhs: AlarmSettingsWire) -> Bool {
@@ -306,6 +313,12 @@ struct NotificationSettingsWire: Hashable {
   var iconColorGreen: Double? = nil
   var iconColorBlue: Double? = nil
   var keepNotificationAfterAlarmEnds: Bool
+  /// Label for the snooze action. Null omits the action.
+  ///
+  /// Only shown when [AlarmSettingsWire.androidSnoozeDurationSeconds] also
+  /// gives it a duration; a label alone describes nothing the platform can
+  /// perform. Android only.
+  var snoozeButton: String? = nil
 
 
   // swift-format-ignore: AlwaysUseLowerCamelCase
@@ -319,6 +332,7 @@ struct NotificationSettingsWire: Hashable {
     let iconColorGreen: Double? = nilOrValue(pigeonVar_list[6])
     let iconColorBlue: Double? = nilOrValue(pigeonVar_list[7])
     let keepNotificationAfterAlarmEnds = pigeonVar_list[8] as! Bool
+    let snoozeButton: String? = nilOrValue(pigeonVar_list[9])
 
     return NotificationSettingsWire(
       title: title,
@@ -329,7 +343,8 @@ struct NotificationSettingsWire: Hashable {
       iconColorRed: iconColorRed,
       iconColorGreen: iconColorGreen,
       iconColorBlue: iconColorBlue,
-      keepNotificationAfterAlarmEnds: keepNotificationAfterAlarmEnds
+      keepNotificationAfterAlarmEnds: keepNotificationAfterAlarmEnds,
+      snoozeButton: snoozeButton
     )
   }
   func toList() -> [Any?] {
@@ -343,9 +358,41 @@ struct NotificationSettingsWire: Hashable {
       iconColorGreen,
       iconColorBlue,
       keepNotificationAfterAlarmEnds,
+      snoozeButton,
     ]
   }
   static func == (lhs: NotificationSettingsWire, rhs: NotificationSettingsWire) -> Bool {
+    return deepEqualsFlutterBindings(lhs.toList(), rhs.toList())  }
+  func hash(into hasher: inout Hasher) {
+    deepHashFlutterBindings(value: toList(), hasher: &hasher)
+  }
+}
+
+/// One deferral taken on the host side.
+///
+/// Generated class from Pigeon that represents data sent in messages.
+struct SnoozedAlarmWire: Hashable {
+  var alarmId: Int64
+  var millisecondsSinceEpoch: Int64
+
+
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ pigeonVar_list: [Any?]) -> SnoozedAlarmWire? {
+    let alarmId = pigeonVar_list[0] as! Int64
+    let millisecondsSinceEpoch = pigeonVar_list[1] as! Int64
+
+    return SnoozedAlarmWire(
+      alarmId: alarmId,
+      millisecondsSinceEpoch: millisecondsSinceEpoch
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      alarmId,
+      millisecondsSinceEpoch,
+    ]
+  }
+  static func == (lhs: SnoozedAlarmWire, rhs: SnoozedAlarmWire) -> Bool {
     return deepEqualsFlutterBindings(lhs.toList(), rhs.toList())  }
   func hash(into hasher: inout Hasher) {
     deepHashFlutterBindings(value: toList(), hasher: &hasher)
@@ -369,6 +416,8 @@ private class FlutterBindingsPigeonCodecReader: FlutterStandardReader {
       return VolumeFadeStepWire.fromList(self.readValue() as! [Any?])
     case 133:
       return NotificationSettingsWire.fromList(self.readValue() as! [Any?])
+    case 134:
+      return SnoozedAlarmWire.fromList(self.readValue() as! [Any?])
     default:
       return super.readValue(ofType: type)
     }
@@ -391,6 +440,9 @@ private class FlutterBindingsPigeonCodecWriter: FlutterStandardWriter {
       super.writeValue(value.toList())
     } else if let value = value as? NotificationSettingsWire {
       super.writeByte(133)
+      super.writeValue(value.toList())
+    } else if let value = value as? SnoozedAlarmWire {
+      super.writeByte(134)
       super.writeValue(value.toList())
     } else {
       super.writeValue(value)
@@ -421,6 +473,15 @@ protocol AlarmApi {
   func isRinging(alarmId: Int64?) throws -> Bool
   func setWarningNotificationOnKill(title: String, body: String) throws
   func disableWarningNotificationOnKill() throws
+  /// Drains the snoozes taken on the host side that no Dart isolate has
+  /// observed yet.
+  ///
+  /// A snooze is normally taken with no engine running: the notification and
+  /// the ringing screen are native, and a full screen intent starts the
+  /// process without starting Flutter. [AlarmTriggerApi.alarmSnoozed] reaches
+  /// nobody in that case, so the deferral is held until an isolate collects
+  /// it. Draining is destructive; a collected snooze is not reported twice.
+  func takeUnreportedSnoozes(completion: @escaping (Result<[SnoozedAlarmWire], Error>) -> Void)
 }
 
 /// Generated setup class from Pigeon to handle messages through the `binaryMessenger`.
@@ -522,12 +583,42 @@ class AlarmApiSetup {
     } else {
       disableWarningNotificationOnKillChannel.setMessageHandler(nil)
     }
+    /// Drains the snoozes taken on the host side that no Dart isolate has
+    /// observed yet.
+    ///
+    /// A snooze is normally taken with no engine running: the notification and
+    /// the ringing screen are native, and a full screen intent starts the
+    /// process without starting Flutter. [AlarmTriggerApi.alarmSnoozed] reaches
+    /// nobody in that case, so the deferral is held until an isolate collects
+    /// it. Draining is destructive; a collected snooze is not reported twice.
+    let takeUnreportedSnoozesChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.alarm.AlarmApi.takeUnreportedSnoozes\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      takeUnreportedSnoozesChannel.setMessageHandler { _, reply in
+        api.takeUnreportedSnoozes { result in
+          switch result {
+          case .success(let res):
+            reply(wrapResult(res))
+          case .failure(let error):
+            reply(wrapError(error))
+          }
+        }
+      }
+    } else {
+      takeUnreportedSnoozesChannel.setMessageHandler(nil)
+    }
   }
 }
 /// Generated protocol from Pigeon that represents Flutter messages that can be called from Swift.
 protocol AlarmTriggerApiProtocol {
   func alarmRang(alarmId alarmIdArg: Int64, completion: @escaping (Result<Void, PigeonError>) -> Void)
   func alarmStopped(alarmId alarmIdArg: Int64, completion: @escaping (Result<Void, PigeonError>) -> Void)
+  /// An alarm was deferred on the host side and re-registered for
+  /// [millisecondsSinceEpoch].
+  ///
+  /// Distinct from [alarmStopped] because the alarm is still owed: reporting a
+  /// snooze as a stop would tell the application the user dismissed something
+  /// they asked to be reminded of again.
+  func alarmSnoozed(alarmId alarmIdArg: Int64, millisecondsSinceEpoch millisecondsSinceEpochArg: Int64, completion: @escaping (Result<Void, PigeonError>) -> Void)
 }
 class AlarmTriggerApi: AlarmTriggerApiProtocol {
   private let binaryMessenger: FlutterBinaryMessenger
@@ -561,6 +652,30 @@ class AlarmTriggerApi: AlarmTriggerApiProtocol {
     let channelName: String = "dev.flutter.pigeon.alarm.AlarmTriggerApi.alarmStopped\(messageChannelSuffix)"
     let channel = FlutterBasicMessageChannel(name: channelName, binaryMessenger: binaryMessenger, codec: codec)
     channel.sendMessage([alarmIdArg] as [Any?]) { response in
+      guard let listResponse = response as? [Any?] else {
+        completion(.failure(createConnectionError(withChannelName: channelName)))
+        return
+      }
+      if listResponse.count > 1 {
+        let code: String = listResponse[0] as! String
+        let message: String? = nilOrValue(listResponse[1])
+        let details: String? = nilOrValue(listResponse[2])
+        completion(.failure(PigeonError(code: code, message: message, details: details)))
+      } else {
+        completion(.success(()))
+      }
+    }
+  }
+  /// An alarm was deferred on the host side and re-registered for
+  /// [millisecondsSinceEpoch].
+  ///
+  /// Distinct from [alarmStopped] because the alarm is still owed: reporting a
+  /// snooze as a stop would tell the application the user dismissed something
+  /// they asked to be reminded of again.
+  func alarmSnoozed(alarmId alarmIdArg: Int64, millisecondsSinceEpoch millisecondsSinceEpochArg: Int64, completion: @escaping (Result<Void, PigeonError>) -> Void) {
+    let channelName: String = "dev.flutter.pigeon.alarm.AlarmTriggerApi.alarmSnoozed\(messageChannelSuffix)"
+    let channel = FlutterBasicMessageChannel(name: channelName, binaryMessenger: binaryMessenger, codec: codec)
+    channel.sendMessage([alarmIdArg, millisecondsSinceEpochArg] as [Any?]) { response in
       guard let listResponse = response as? [Any?] else {
         completion(.failure(createConnectionError(withChannelName: channelName)))
         return

--- a/ios/alarm/Sources/alarm/generated/FlutterBindings.g.swift
+++ b/ios/alarm/Sources/alarm/generated/FlutterBindings.g.swift
@@ -164,10 +164,13 @@ struct AlarmSettingsWire: Hashable {
   var iOSBackgroundAudio: Bool
   var androidStopAlarmOnTermination: Bool
   var preferConnectedAudioDevice: Bool
-  /// How long the snooze action defers the alarm, in seconds.
+  /// How long the snooze action defers the alarm, in milliseconds.
   ///
-  /// Null, or anything below one, offers no snooze. Android only.
-  var androidSnoozeDurationSeconds: Int64? = nil
+  /// Null, or anything below one minute, offers no snooze. The floor exists
+  /// because Android scheduling falls back to a plain `Handler.postDelayed`
+  /// below a few seconds, which survives neither process death nor
+  /// cancellation. Android only.
+  var androidSnoozeDurationMillis: Int64? = nil
 
 
   // swift-format-ignore: AlwaysUseLowerCamelCase
@@ -186,7 +189,7 @@ struct AlarmSettingsWire: Hashable {
     let iOSBackgroundAudio = pigeonVar_list[11] as! Bool
     let androidStopAlarmOnTermination = pigeonVar_list[12] as! Bool
     let preferConnectedAudioDevice = pigeonVar_list[13] as! Bool
-    let androidSnoozeDurationSeconds: Int64? = nilOrValue(pigeonVar_list[14])
+    let androidSnoozeDurationMillis: Int64? = nilOrValue(pigeonVar_list[14])
 
     return AlarmSettingsWire(
       id: id,
@@ -203,7 +206,7 @@ struct AlarmSettingsWire: Hashable {
       iOSBackgroundAudio: iOSBackgroundAudio,
       androidStopAlarmOnTermination: androidStopAlarmOnTermination,
       preferConnectedAudioDevice: preferConnectedAudioDevice,
-      androidSnoozeDurationSeconds: androidSnoozeDurationSeconds
+      androidSnoozeDurationMillis: androidSnoozeDurationMillis
     )
   }
   func toList() -> [Any?] {
@@ -222,7 +225,7 @@ struct AlarmSettingsWire: Hashable {
       iOSBackgroundAudio,
       androidStopAlarmOnTermination,
       preferConnectedAudioDevice,
-      androidSnoozeDurationSeconds,
+      androidSnoozeDurationMillis,
     ]
   }
   static func == (lhs: AlarmSettingsWire, rhs: AlarmSettingsWire) -> Bool {
@@ -315,9 +318,9 @@ struct NotificationSettingsWire: Hashable {
   var keepNotificationAfterAlarmEnds: Bool
   /// Label for the snooze action. Null omits the action.
   ///
-  /// Only shown when [AlarmSettingsWire.androidSnoozeDurationSeconds] also
-  /// gives it a duration; a label alone describes nothing the platform can
-  /// perform. Android only.
+  /// Only shown when [AlarmSettingsWire.androidSnoozeDurationMillis] also
+  /// gives it a usable duration; a label alone describes nothing the platform
+  /// can perform. Android only.
   var snoozeButton: String? = nil
 
 
@@ -368,20 +371,20 @@ struct NotificationSettingsWire: Hashable {
   }
 }
 
-/// One deferral taken on the host side.
+/// A snooze the host recorded and Dart has not yet applied.
 ///
 /// Generated class from Pigeon that represents data sent in messages.
-struct SnoozedAlarmWire: Hashable {
+struct PendingSnoozeWire: Hashable {
   var alarmId: Int64
   var millisecondsSinceEpoch: Int64
 
 
   // swift-format-ignore: AlwaysUseLowerCamelCase
-  static func fromList(_ pigeonVar_list: [Any?]) -> SnoozedAlarmWire? {
+  static func fromList(_ pigeonVar_list: [Any?]) -> PendingSnoozeWire? {
     let alarmId = pigeonVar_list[0] as! Int64
     let millisecondsSinceEpoch = pigeonVar_list[1] as! Int64
 
-    return SnoozedAlarmWire(
+    return PendingSnoozeWire(
       alarmId: alarmId,
       millisecondsSinceEpoch: millisecondsSinceEpoch
     )
@@ -392,7 +395,7 @@ struct SnoozedAlarmWire: Hashable {
       millisecondsSinceEpoch,
     ]
   }
-  static func == (lhs: SnoozedAlarmWire, rhs: SnoozedAlarmWire) -> Bool {
+  static func == (lhs: PendingSnoozeWire, rhs: PendingSnoozeWire) -> Bool {
     return deepEqualsFlutterBindings(lhs.toList(), rhs.toList())  }
   func hash(into hasher: inout Hasher) {
     deepHashFlutterBindings(value: toList(), hasher: &hasher)
@@ -417,7 +420,7 @@ private class FlutterBindingsPigeonCodecReader: FlutterStandardReader {
     case 133:
       return NotificationSettingsWire.fromList(self.readValue() as! [Any?])
     case 134:
-      return SnoozedAlarmWire.fromList(self.readValue() as! [Any?])
+      return PendingSnoozeWire.fromList(self.readValue() as! [Any?])
     default:
       return super.readValue(ofType: type)
     }
@@ -441,7 +444,7 @@ private class FlutterBindingsPigeonCodecWriter: FlutterStandardWriter {
     } else if let value = value as? NotificationSettingsWire {
       super.writeByte(133)
       super.writeValue(value.toList())
-    } else if let value = value as? SnoozedAlarmWire {
+    } else if let value = value as? PendingSnoozeWire {
       super.writeByte(134)
       super.writeValue(value.toList())
     } else {
@@ -473,15 +476,24 @@ protocol AlarmApi {
   func isRinging(alarmId: Int64?) throws -> Bool
   func setWarningNotificationOnKill(title: String, body: String) throws
   func disableWarningNotificationOnKill() throws
-  /// Drains the snoozes taken on the host side that no Dart isolate has
-  /// observed yet.
+  /// Lists snoozes the host has recorded but Dart has not yet applied.
   ///
-  /// A snooze is normally taken with no engine running: the notification and
-  /// the ringing screen are native, and a full screen intent starts the
-  /// process without starting Flutter. [AlarmTriggerApi.alarmSnoozed] reaches
-  /// nobody in that case, so the deferral is held until an isolate collects
-  /// it. Draining is destructive; a collected snooze is not reported twice.
-  func takeUnreportedSnoozes(completion: @escaping (Result<[SnoozedAlarmWire], Error>) -> Void)
+  /// A snooze is normally taken with no engine running: the notification is
+  /// native and a full screen intent starts the process without starting
+  /// Flutter, so [AlarmTriggerApi.alarmSnoozed] reaches nobody. The host holds
+  /// a marker until Dart has durably applied it.
+  ///
+  /// Reading is **not** destructive — the marker survives until
+  /// [acknowledgeSnooze] confirms Dart wrote the new time. A read that is
+  /// followed by a crash therefore loses nothing.
+  func getPendingSnoozes(completion: @escaping (Result<[PendingSnoozeWire], Error>) -> Void)
+  /// Drops the marker for [alarmId], but only if it still records exactly
+  /// [nextRingAtMillis].
+  ///
+  /// Matching on the timestamp as well as the id means a late acknowledgement
+  /// for an earlier snooze cannot discard a newer one taken for the same
+  /// alarm in the meantime.
+  func acknowledgeSnooze(alarmId: Int64, nextRingAtMillis: Int64, completion: @escaping (Result<Void, Error>) -> Void)
 }
 
 /// Generated setup class from Pigeon to handle messages through the `binaryMessenger`.
@@ -583,18 +595,20 @@ class AlarmApiSetup {
     } else {
       disableWarningNotificationOnKillChannel.setMessageHandler(nil)
     }
-    /// Drains the snoozes taken on the host side that no Dart isolate has
-    /// observed yet.
+    /// Lists snoozes the host has recorded but Dart has not yet applied.
     ///
-    /// A snooze is normally taken with no engine running: the notification and
-    /// the ringing screen are native, and a full screen intent starts the
-    /// process without starting Flutter. [AlarmTriggerApi.alarmSnoozed] reaches
-    /// nobody in that case, so the deferral is held until an isolate collects
-    /// it. Draining is destructive; a collected snooze is not reported twice.
-    let takeUnreportedSnoozesChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.alarm.AlarmApi.takeUnreportedSnoozes\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+    /// A snooze is normally taken with no engine running: the notification is
+    /// native and a full screen intent starts the process without starting
+    /// Flutter, so [AlarmTriggerApi.alarmSnoozed] reaches nobody. The host holds
+    /// a marker until Dart has durably applied it.
+    ///
+    /// Reading is **not** destructive — the marker survives until
+    /// [acknowledgeSnooze] confirms Dart wrote the new time. A read that is
+    /// followed by a crash therefore loses nothing.
+    let getPendingSnoozesChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.alarm.AlarmApi.getPendingSnoozes\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
-      takeUnreportedSnoozesChannel.setMessageHandler { _, reply in
-        api.takeUnreportedSnoozes { result in
+      getPendingSnoozesChannel.setMessageHandler { _, reply in
+        api.getPendingSnoozes { result in
           switch result {
           case .success(let res):
             reply(wrapResult(res))
@@ -604,7 +618,31 @@ class AlarmApiSetup {
         }
       }
     } else {
-      takeUnreportedSnoozesChannel.setMessageHandler(nil)
+      getPendingSnoozesChannel.setMessageHandler(nil)
+    }
+    /// Drops the marker for [alarmId], but only if it still records exactly
+    /// [nextRingAtMillis].
+    ///
+    /// Matching on the timestamp as well as the id means a late acknowledgement
+    /// for an earlier snooze cannot discard a newer one taken for the same
+    /// alarm in the meantime.
+    let acknowledgeSnoozeChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.alarm.AlarmApi.acknowledgeSnooze\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      acknowledgeSnoozeChannel.setMessageHandler { message, reply in
+        let args = message as! [Any?]
+        let alarmIdArg = args[0] as! Int64
+        let nextRingAtMillisArg = args[1] as! Int64
+        api.acknowledgeSnooze(alarmId: alarmIdArg, nextRingAtMillis: nextRingAtMillisArg) { result in
+          switch result {
+          case .success:
+            reply(wrapResult(nil))
+          case .failure(let error):
+            reply(wrapError(error))
+          }
+        }
+      }
+    } else {
+      acknowledgeSnoozeChannel.setMessageHandler(nil)
     }
   }
 }

--- a/ios/alarm/Sources/alarm/generated/FlutterBindings.g.swift
+++ b/ios/alarm/Sources/alarm/generated/FlutterBindings.g.swift
@@ -321,7 +321,7 @@ struct NotificationSettingsWire: Hashable {
   /// Only shown when [AlarmSettingsWire.androidSnoozeDurationMillis] also
   /// gives it a usable duration; a label alone describes nothing the platform
   /// can perform. Android only.
-  var snoozeButton: String? = nil
+  var androidSnoozeButton: String? = nil
 
 
   // swift-format-ignore: AlwaysUseLowerCamelCase
@@ -335,7 +335,7 @@ struct NotificationSettingsWire: Hashable {
     let iconColorGreen: Double? = nilOrValue(pigeonVar_list[6])
     let iconColorBlue: Double? = nilOrValue(pigeonVar_list[7])
     let keepNotificationAfterAlarmEnds = pigeonVar_list[8] as! Bool
-    let snoozeButton: String? = nilOrValue(pigeonVar_list[9])
+    let androidSnoozeButton: String? = nilOrValue(pigeonVar_list[9])
 
     return NotificationSettingsWire(
       title: title,
@@ -347,7 +347,7 @@ struct NotificationSettingsWire: Hashable {
       iconColorGreen: iconColorGreen,
       iconColorBlue: iconColorBlue,
       keepNotificationAfterAlarmEnds: keepNotificationAfterAlarmEnds,
-      snoozeButton: snoozeButton
+      androidSnoozeButton: androidSnoozeButton
     )
   }
   func toList() -> [Any?] {
@@ -361,7 +361,7 @@ struct NotificationSettingsWire: Hashable {
       iconColorGreen,
       iconColorBlue,
       keepNotificationAfterAlarmEnds,
-      snoozeButton,
+      androidSnoozeButton,
     ]
   }
   static func == (lhs: NotificationSettingsWire, rhs: NotificationSettingsWire) -> Bool {

--- a/lib/alarm.dart
+++ b/lib/alarm.dart
@@ -84,7 +84,17 @@ class Alarm {
 
   /// Checks if some alarms were set on previous session.
   /// If it's the case then reschedules them.
-  static Future<void> checkAlarm() async {
+  ///
+  /// Single-flight: concurrent callers share one pass rather than interleaving
+  /// two reconciliations over the same alarms.
+  static Future<void> checkAlarm() =>
+      _checkAlarmFuture ??= _checkAlarm().whenComplete(() {
+        _checkAlarmFuture = null;
+      });
+
+  static Future<void>? _checkAlarmFuture;
+
+  static Future<void> _checkAlarm() async {
     final snoozed = await _applyPendingSnoozes();
 
     final alarms = await getAlarms();
@@ -112,6 +122,16 @@ class Alarm {
           _ringing.add(_ringing.value.add(alarm));
           ringStream.add(alarm);
         } else {
+          // Re-read before destroying anything. Every await above is a window
+          // in which a snooze can land, and the snapshot this loop iterates
+          // would still show the pre-snooze time — stopping here would cancel a
+          // deferral the user just asked for.
+          final current = await getAlarm(alarm.id);
+          if (current != null && current.dateTime.isAfter(DateTime.now())) {
+            _log.info('Alarm ${alarm.id} moved to ${current.dateTime} while '
+                'reconciling, so it is left scheduled.');
+            continue;
+          }
           await stop(alarm.id);
         }
       }
@@ -175,6 +195,44 @@ class Alarm {
         message:
             'Alarm id cannot be set smaller than Int min value (-2147483648). '
             'Provided: ${alarmSettings.id}',
+      );
+    }
+
+    final snoozeDuration = alarmSettings.androidSnoozeDuration;
+    if (snoozeDuration != null && snoozeDuration <= Duration.zero) {
+      throw AlarmException(
+        AlarmErrorCode.invalidArguments,
+        message: 'androidSnoozeDuration must be positive. '
+            'Provided: $snoozeDuration',
+      );
+    }
+
+    // Everything below only warns. These settings are inert on iOS, and
+    // NotificationSettings is shared across platforms, so throwing would break
+    // apps that configure a snooze label once for both.
+    final snoozeLabel = alarmSettings.notificationSettings.androidSnoozeButton;
+    final snoozeIsUsable = snoozeDuration != null &&
+        snoozeDuration >= AlarmSettings.minSnoozeDuration;
+
+    if (snoozeDuration != null && !snoozeIsUsable) {
+      _log.warning(
+        'Alarm ${alarmSettings.id} has androidSnoozeDuration $snoozeDuration, '
+        'which is below the ${AlarmSettings.minSnoozeDuration} minimum, so no '
+        'snooze will be offered.',
+      );
+    }
+    if (snoozeLabel != null && !snoozeIsUsable) {
+      _log.warning(
+        'Alarm ${alarmSettings.id} sets a snooze button labelled '
+        '"$snoozeLabel" but no usable androidSnoozeDuration, so the button '
+        'will not be shown.',
+      );
+    }
+    if (snoozeIsUsable && snoozeLabel == null) {
+      _log.warning(
+        'Alarm ${alarmSettings.id} has an androidSnoozeDuration but no '
+        'NotificationSettings.androidSnoozeButton label, so the notification '
+        'will not offer a snooze.',
       );
     }
   }

--- a/lib/alarm.dart
+++ b/lib/alarm.dart
@@ -9,6 +9,7 @@ import 'package:alarm/src/alarm_trigger_api_impl.dart';
 import 'package:alarm/src/android_alarm.dart';
 import 'package:alarm/src/generated/platform_bindings.g.dart';
 import 'package:alarm/src/ios_alarm.dart';
+import 'package:alarm/src/platform_timers.dart';
 import 'package:alarm/utils/alarm_exception.dart';
 import 'package:alarm/utils/alarm_set.dart';
 import 'package:alarm/utils/extensions.dart';
@@ -84,13 +85,19 @@ class Alarm {
   /// Checks if some alarms were set on previous session.
   /// If it's the case then reschedules them.
   static Future<void> checkAlarm() async {
-    await _reportUnobservedSnoozes();
+    final snoozed = await _applyPendingSnoozes();
 
     final alarms = await getAlarms();
 
     if (iOS) await stopAll();
 
     for (final alarm in alarms) {
+      // Just reconciled from a snooze marker: the native alarm is already
+      // armed for the new time and both stores agree, so set() would only
+      // cancel and re-arm it — and stop() inside set() reports a spurious
+      // alarmStopped on the way through.
+      if (snoozed.contains(alarm.id)) continue;
+
       final now = DateTime.now();
       if (alarm.dateTime.isAfter(now)) {
         await set(alarmSettings: alarm);
@@ -282,41 +289,94 @@ class Alarm {
     ringStream.add(alarm);
   }
 
-  /// Replays snoozes the host recorded while no isolate was listening.
+  /// Applies snoozes the host recorded while no isolate was listening.
   ///
-  /// The notification and the ringing screen are native, and a full screen
-  /// intent starts the process without starting Flutter, so a deferral taken
-  /// there is normally observed only here.
-  static Future<void> _reportUnobservedSnoozes() async {
-    final List<SnoozedAlarmWire> unreported;
+  /// The notification is native and a full screen intent starts the process
+  /// without starting Flutter, so a deferral taken there is normally observed
+  /// only here. Runs before [checkAlarm]'s reschedule loop: until the shifted
+  /// time is in Dart storage, that loop sees the original past time and stops
+  /// the alarm, undoing the snooze.
+  ///
+  /// Ids that were applied here are returned so the caller can leave them
+  /// alone — the native alarm and native storage are already correct, so
+  /// rescheduling them would cancel and re-arm for no reason.
+  static Future<Set<int>> _applyPendingSnoozes() async {
+    final List<PendingSnoozeWire> pending;
     try {
-      unreported = await AlarmApi().takeUnreportedSnoozes();
+      pending = await AlarmApi().getPendingSnoozes();
     } on Object catch (error) {
-      _log.warning('Could not read unreported snoozes: $error');
-      return;
+      // Never let this break init: fall through to the normal reschedule loop.
+      _log.warning('Could not read pending snoozes: $error');
+      return {};
     }
 
-    for (final snooze in unreported) {
-      await _alarmSnoozed(
-        snooze.alarmId,
-        DateTime.fromMillisecondsSinceEpoch(snooze.millisecondsSinceEpoch),
-      );
+    final applied = <int>{};
+    for (final snooze in pending) {
+      final nextRingAt =
+          DateTime.fromMillisecondsSinceEpoch(snooze.millisecondsSinceEpoch);
+      try {
+        if (await _applySnooze(snooze.alarmId, nextRingAt)) {
+          applied.add(snooze.alarmId);
+        }
+        // Acknowledged either way: an applied snooze is durable, and one that
+        // could not be applied is not going to become applicable later.
+        await AlarmApi().acknowledgeSnooze(
+          alarmId: snooze.alarmId,
+          nextRingAtMillis: snooze.millisecondsSinceEpoch,
+        );
+      } on Object catch (error) {
+        _log.warning('Could not apply snooze ${snooze.alarmId}: $error');
+      }
     }
+    return applied;
   }
 
   /// PRIVATE: Called by the native platform when an alarm was deferred there.
-  ///
-  /// The alarm stops ringing and returns to the scheduled set rather than
-  /// leaving it: a snoozed alarm is still owed.
   static Future<void> _alarmSnoozed(int alarmId, DateTime nextRingAt) async {
-    _ringing.add(_ringing.value.removeById(alarmId));
+    await _applySnooze(alarmId, nextRingAt);
+  }
 
+  /// Moves [alarmId] to [nextRingAt] in Dart's own state, and reports it.
+  ///
+  /// Shared by the live callback and startup reconciliation so both produce
+  /// the same result. Idempotent: applying a snooze already applied changes
+  /// nothing and emits nothing.
+  ///
+  /// Returns whether the alarm now rings at [nextRingAt].
+  static Future<bool> _applySnooze(int alarmId, DateTime nextRingAt) async {
     final alarm = await getAlarm(alarmId);
-    if (alarm != null) {
-      _scheduled.add(_scheduled.value.removeById(alarmId).add(alarm));
+    if (alarm == null) {
+      _log.severe('Alarm $alarmId was snoozed but is not in storage, so the '
+          'deferral cannot be applied. The alarm will not ring again.');
+      return false;
     }
+
+    // A marker whose time has already passed would rewrite the alarm to a past
+    // time, which checkAlarm then deletes. Refuse rather than destroy it.
+    if (!nextRingAt.isAfter(DateTime.now())) {
+      _log.warning('Ignoring snooze for $alarmId: $nextRingAt is not in the '
+          'future.');
+      return false;
+    }
+
+    // Already applied: leave state and streams untouched so the live report
+    // and a replayed marker for the same snooze collapse into one effect.
+    if (!alarm.dateTime.isBefore(nextRingAt)) return true;
+
+    final snoozedAlarm = alarm.copyWith(dateTime: nextRingAt);
+    await AlarmStorage.saveAlarm(snoozedAlarm);
+
+    // The fallback timer still holds the pre-snooze time. Left alone it fires
+    // immediately on the next foreground and reports a phantom ring, which
+    // would evict the snoozed alarm from [scheduled].
+    PlatformTimers.stopAlarm(alarmId);
+    PlatformTimers.setAlarm(snoozedAlarm);
+
+    _ringing.add(_ringing.value.removeById(alarmId));
+    _scheduled.add(_scheduled.value.removeById(alarmId).add(snoozedAlarm));
     _snoozed.add((id: alarmId, nextRingAt: nextRingAt));
     updateStream.add(alarmId);
+    return true;
   }
 
   static Future<void> _alarmStopped(int alarmId) async {

--- a/lib/alarm.dart
+++ b/lib/alarm.dart
@@ -173,6 +173,20 @@ class Alarm {
     return success;
   }
 
+  /// Returns this class to the state a fresh isolate would see.
+  ///
+  /// Only for tests. [scheduled] and [ringing] are static subjects and
+  /// [checkAlarm] is single-flight, so without this one test's alarms and
+  /// in-flight reconciliation are still there for the next one. Reset
+  /// `AlarmStorage` and `AlarmTriggerApiImpl` alongside it.
+  @visibleForTesting
+  static void resetForTesting() {
+    _checkAlarmFuture = null;
+    _scheduled.add(AlarmSet.empty());
+    _ringing.add(AlarmSet.empty());
+    PlatformTimers.stopAll();
+  }
+
   /// Validates [alarmSettings] fields.
   static void alarmSettingsValidation(AlarmSettings alarmSettings) {
     if (alarmSettings.id == 0 || alarmSettings.id == -1) {

--- a/lib/alarm.dart
+++ b/lib/alarm.dart
@@ -431,23 +431,36 @@ class Alarm {
       return false;
     }
 
-    // Already applied: leave state and streams untouched so the live report
-    // and a replayed marker for the same snooze collapse into one effect.
-    if (!alarm.dateTime.isBefore(nextRingAt)) return true;
+    // Whether this deferral is news. A marker replayed after the stored time
+    // already moved has nothing to write — but that is not the same as having
+    // nothing to do, because process-local state does not survive a restart.
+    final isNewDeferral = alarm.dateTime.isBefore(nextRingAt);
+    final snoozedAlarm =
+        isNewDeferral ? alarm.copyWith(dateTime: nextRingAt) : alarm;
 
-    final snoozedAlarm = alarm.copyWith(dateTime: nextRingAt);
-    await AlarmStorage.saveAlarm(snoozedAlarm);
+    if (isNewDeferral) await AlarmStorage.saveAlarm(snoozedAlarm);
 
-    // The fallback timer still holds the pre-snooze time. Left alone it fires
-    // immediately on the next foreground and reports a phantom ring, which
-    // would evict the snoozed alarm from [scheduled].
+    // Reconciled every time, including for an already-applied marker. A fresh
+    // isolate starts with empty sets and no timers whatever storage says, and
+    // [checkAlarm] skips the ids applied here, so this is the only thing that
+    // surfaces them. The fallback timer also still holds the pre-snooze time,
+    // and left alone it fires immediately on the next foreground and reports a
+    // phantom ring, which would evict the snoozed alarm from [scheduled].
     PlatformTimers.stopAlarm(alarmId);
     PlatformTimers.setAlarm(snoozedAlarm);
 
-    _ringing.add(_ringing.value.removeById(alarmId));
-    _scheduled.add(_scheduled.value.removeById(alarmId).add(snoozedAlarm));
-    _snoozed.add((id: alarmId, nextRingAt: nextRingAt));
-    updateStream.add(alarmId);
+    final nextRinging = _ringing.value.removeById(alarmId);
+    if (nextRinging != _ringing.value) _ringing.add(nextRinging);
+
+    final nextScheduled =
+        _scheduled.value.removeById(alarmId).add(snoozedAlarm);
+    if (nextScheduled != _scheduled.value) _scheduled.add(nextScheduled);
+
+    // Only a deferral that actually moved the alarm is an event.
+    if (isNewDeferral) {
+      _snoozed.add((id: alarmId, nextRingAt: nextRingAt));
+      updateStream.add(alarmId);
+    }
     return true;
   }
 

--- a/lib/alarm.dart
+++ b/lib/alarm.dart
@@ -34,11 +34,22 @@ class Alarm {
 
   static final _ringing = BehaviorSubject<AlarmSet>.seeded(AlarmSet.empty());
 
+  static final _snoozed =
+      StreamController<({int id, DateTime nextRingAt})>.broadcast();
+
   /// Stream of the scheduled alarms.
   static ValueStream<AlarmSet> get scheduled => _scheduled.stream;
 
   /// Stream of the ringing alarms.
   static ValueStream<AlarmSet> get ringing => _ringing.stream;
+
+  /// Stream of alarms deferred on the host side, with the instant each one
+  /// rings again.
+  ///
+  /// A snooze never reaches [ringing] as a stop: the alarm is still owed, and
+  /// an application tracking its own alarm state needs to record a deferral
+  /// rather than a dismissal.
+  static Stream<({int id, DateTime nextRingAt})> get snoozed => _snoozed.stream;
 
   /// Stream of the alarm updates.
   ///
@@ -62,6 +73,7 @@ class Alarm {
     AlarmTriggerApiImpl.ensureInitialized(
       alarmRang: alarmRang,
       alarmStopped: _alarmStopped,
+      alarmSnoozed: _alarmSnoozed,
     );
 
     await AlarmStorage.init();
@@ -72,6 +84,8 @@ class Alarm {
   /// Checks if some alarms were set on previous session.
   /// If it's the case then reschedules them.
   static Future<void> checkAlarm() async {
+    await _reportUnobservedSnoozes();
+
     final alarms = await getAlarms();
 
     if (iOS) await stopAll();
@@ -266,6 +280,43 @@ class Alarm {
     _scheduled.add(_scheduled.value.remove(alarm));
     _ringing.add(_ringing.value.add(alarm));
     ringStream.add(alarm);
+  }
+
+  /// Replays snoozes the host recorded while no isolate was listening.
+  ///
+  /// The notification and the ringing screen are native, and a full screen
+  /// intent starts the process without starting Flutter, so a deferral taken
+  /// there is normally observed only here.
+  static Future<void> _reportUnobservedSnoozes() async {
+    final List<SnoozedAlarmWire> unreported;
+    try {
+      unreported = await AlarmApi().takeUnreportedSnoozes();
+    } on Object catch (error) {
+      _log.warning('Could not read unreported snoozes: $error');
+      return;
+    }
+
+    for (final snooze in unreported) {
+      await _alarmSnoozed(
+        snooze.alarmId,
+        DateTime.fromMillisecondsSinceEpoch(snooze.millisecondsSinceEpoch),
+      );
+    }
+  }
+
+  /// PRIVATE: Called by the native platform when an alarm was deferred there.
+  ///
+  /// The alarm stops ringing and returns to the scheduled set rather than
+  /// leaving it: a snoozed alarm is still owed.
+  static Future<void> _alarmSnoozed(int alarmId, DateTime nextRingAt) async {
+    _ringing.add(_ringing.value.removeById(alarmId));
+
+    final alarm = await getAlarm(alarmId);
+    if (alarm != null) {
+      _scheduled.add(_scheduled.value.removeById(alarmId).add(alarm));
+    }
+    _snoozed.add((id: alarmId, nextRingAt: nextRingAt));
+    updateStream.add(alarmId);
   }
 
   static Future<void> _alarmStopped(int alarmId) async {

--- a/lib/model/alarm_settings.dart
+++ b/lib/model/alarm_settings.dart
@@ -286,7 +286,7 @@ class AlarmSettings extends Equatable {
     bool? androidStopAlarmOnTermination,
     bool? preferConnectedAudioDevice,
     String? Function()? payload,
-    Duration? androidSnoozeDuration,
+    Duration? Function()? androidSnoozeDuration,
   }) {
     return AlarmSettings(
       id: id ?? this.id,
@@ -311,8 +311,11 @@ class AlarmSettings extends Equatable {
       // The function wrapper allows callers to clear the payload by
       // explicitly returning null.
       payload: payload != null ? payload() : this.payload,
-      androidSnoozeDuration:
-          androidSnoozeDuration ?? this.androidSnoozeDuration,
+      // Wrapped like payload so a caller can remove an existing snooze by
+      // returning null, which a plain nullable parameter cannot express.
+      androidSnoozeDuration: androidSnoozeDuration != null
+          ? androidSnoozeDuration()
+          : this.androidSnoozeDuration,
     );
   }
 

--- a/lib/model/alarm_settings.dart
+++ b/lib/model/alarm_settings.dart
@@ -214,11 +214,14 @@ class AlarmSettings extends Equatable {
 
   /// How long the snooze action defers this alarm.
   ///
-  /// **Android only.** When set, and when [NotificationSettings.snoozeButton]
-  /// gives it a label, the alarm notification offers a snooze that stops the
-  /// current ring and re-registers the alarm this far ahead.
+  /// **Android only.** When set, and when
+  /// [NotificationSettings.androidSnoozeButton] gives it a label, the alarm
+  /// notification offers a snooze that stops the current ring and re-registers
+  /// the alarm this far ahead.
   ///
-  /// Null, or anything under a second, offers no snooze.
+  /// Null, or anything under a minute, offers no snooze. The minimum exists
+  /// because Android scheduling stops using `AlarmManager` for very short
+  /// delays, and the fallback survives neither process death nor cancellation.
   final Duration? androidSnoozeDuration;
 
   /// Converts the `AlarmSettings` instance to a JSON object.

--- a/lib/model/alarm_settings.dart
+++ b/lib/model/alarm_settings.dart
@@ -93,6 +93,14 @@ class AlarmSettings extends Equatable {
 
   static final _log = Logger('AlarmSettings');
 
+  /// Shortest [androidSnoozeDuration] the platform will honour.
+  ///
+  /// Below this, Android scheduling stops using `AlarmManager` and falls back
+  /// to an in-process timer that survives neither process death nor
+  /// cancellation — so a shorter snooze could be neither guaranteed nor undone.
+  /// A shorter duration offers no snooze at all rather than an unreliable one.
+  static const minSnoozeDuration = Duration(minutes: 1);
+
   /// Unique identifier associated with the alarm. Cannot be 0 or -1.
   final int id;
 

--- a/lib/model/alarm_settings.dart
+++ b/lib/model/alarm_settings.dart
@@ -27,6 +27,7 @@ class AlarmSettings extends Equatable {
     this.androidStopAlarmOnTermination = true,
     this.preferConnectedAudioDevice = false,
     this.payload,
+    this.androidSnoozeDuration,
   });
 
   /// Constructs an `AlarmSettings` instance from the given JSON data.
@@ -211,6 +212,15 @@ class AlarmSettings extends Equatable {
   /// Caller is responsible for serializing and parsing the payload.
   final String? payload;
 
+  /// How long the snooze action defers this alarm.
+  ///
+  /// **Android only.** When set, and when [NotificationSettings.snoozeButton]
+  /// gives it a label, the alarm notification offers a snooze that stops the
+  /// current ring and re-registers the alarm this far ahead.
+  ///
+  /// Null, or anything under a second, offers no snooze.
+  final Duration? androidSnoozeDuration;
+
   /// Converts the `AlarmSettings` instance to a JSON object.
   Map<String, dynamic> toJson() => _$AlarmSettingsToJson(this);
 
@@ -230,6 +240,7 @@ class AlarmSettings extends Equatable {
         iOSBackgroundAudio: iOSBackgroundAudio,
         androidStopAlarmOnTermination: androidStopAlarmOnTermination,
         preferConnectedAudioDevice: preferConnectedAudioDevice,
+        androidSnoozeDurationSeconds: androidSnoozeDuration?.inSeconds,
       );
 
   /// Creates a copy of `AlarmSettings` but with the given fields replaced with
@@ -264,6 +275,7 @@ class AlarmSettings extends Equatable {
     bool? androidStopAlarmOnTermination,
     bool? preferConnectedAudioDevice,
     String? Function()? payload,
+    Duration? androidSnoozeDuration,
   }) {
     return AlarmSettings(
       id: id ?? this.id,
@@ -288,6 +300,8 @@ class AlarmSettings extends Equatable {
       // The function wrapper allows callers to clear the payload by
       // explicitly returning null.
       payload: payload != null ? payload() : this.payload,
+      androidSnoozeDuration:
+          androidSnoozeDuration ?? this.androidSnoozeDuration,
     );
   }
 
@@ -308,5 +322,6 @@ class AlarmSettings extends Equatable {
         androidStopAlarmOnTermination,
         preferConnectedAudioDevice,
         payload,
+        androidSnoozeDuration,
       ];
 }

--- a/lib/model/alarm_settings.dart
+++ b/lib/model/alarm_settings.dart
@@ -240,7 +240,7 @@ class AlarmSettings extends Equatable {
         iOSBackgroundAudio: iOSBackgroundAudio,
         androidStopAlarmOnTermination: androidStopAlarmOnTermination,
         preferConnectedAudioDevice: preferConnectedAudioDevice,
-        androidSnoozeDurationSeconds: androidSnoozeDuration?.inSeconds,
+        androidSnoozeDurationMillis: androidSnoozeDuration?.inMilliseconds,
       );
 
   /// Creates a copy of `AlarmSettings` but with the given fields replaced with

--- a/lib/model/alarm_settings.g.dart
+++ b/lib/model/alarm_settings.g.dart
@@ -65,6 +65,6 @@ Map<String, dynamic> _$AlarmSettingsToJson(AlarmSettings instance) =>
       'androidStopAlarmOnTermination': instance.androidStopAlarmOnTermination,
       'preferConnectedAudioDevice': instance.preferConnectedAudioDevice,
       if (instance.payload case final value?) 'payload': value,
-      if (instance.androidSnoozeDuration case final value?)
-        'androidSnoozeDuration': value.inMicroseconds,
+      if (instance.androidSnoozeDuration?.inMicroseconds case final value?)
+        'androidSnoozeDuration': value,
     };

--- a/lib/model/alarm_settings.g.dart
+++ b/lib/model/alarm_settings.g.dart
@@ -38,6 +38,11 @@ AlarmSettings _$AlarmSettingsFromJson(Map<String, dynamic> json) =>
           preferConnectedAudioDevice: $checkedConvert(
               'preferConnectedAudioDevice', (v) => v as bool? ?? false),
           payload: $checkedConvert('payload', (v) => v as String?),
+          androidSnoozeDuration: $checkedConvert(
+              'androidSnoozeDuration',
+              (v) => v == null
+                  ? null
+                  : Duration(microseconds: (v as num).toInt())),
         );
         return val;
       },
@@ -60,4 +65,6 @@ Map<String, dynamic> _$AlarmSettingsToJson(AlarmSettings instance) =>
       'androidStopAlarmOnTermination': instance.androidStopAlarmOnTermination,
       'preferConnectedAudioDevice': instance.preferConnectedAudioDevice,
       if (instance.payload case final value?) 'payload': value,
+      if (instance.androidSnoozeDuration case final value?)
+        'androidSnoozeDuration': value.inMicroseconds,
     };

--- a/lib/model/notification_settings.dart
+++ b/lib/model/notification_settings.dart
@@ -118,7 +118,7 @@ class NotificationSettings extends Equatable {
     String? title,
     String? body,
     String? stopButton,
-    String? androidSnoozeButton,
+    String? Function()? androidSnoozeButton,
     String? icon,
     Color? iconColor,
     bool? keepNotificationAfterAlarmEnds,
@@ -127,7 +127,11 @@ class NotificationSettings extends Equatable {
       title: title ?? this.title,
       body: body ?? this.body,
       stopButton: stopButton ?? this.stopButton,
-      androidSnoozeButton: androidSnoozeButton ?? this.androidSnoozeButton,
+      // Wrapped so a caller can remove the snooze action; the older nullable
+      // fields keep their existing signatures for compatibility.
+      androidSnoozeButton: androidSnoozeButton != null
+          ? androidSnoozeButton()
+          : this.androidSnoozeButton,
       icon: icon ?? this.icon,
       iconColor: iconColor ?? this.iconColor,
       keepNotificationAfterAlarmEnds:

--- a/lib/model/notification_settings.dart
+++ b/lib/model/notification_settings.dart
@@ -16,6 +16,7 @@ class NotificationSettings extends Equatable {
     required this.title,
     required this.body,
     this.stopButton,
+    this.snoozeButton,
     this.icon,
     this.iconColor,
     this.keepNotificationAfterAlarmEnds = false,
@@ -36,6 +37,15 @@ class NotificationSettings extends Equatable {
   /// Won't work on iOS if app was killed.
   /// If null, button will not be shown. Null by default.
   final String? stopButton;
+
+  /// The text to display on the snooze button of the notification.
+  ///
+  /// **Android only.** Shown only when `AlarmSettings.androidSnoozeDuration`
+  /// also gives it a duration; a label alone describes nothing the platform
+  /// can perform.
+  ///
+  /// If null, button will not be shown. Null by default.
+  final String? snoozeButton;
 
   /// The icon to display on the notification.
   ///
@@ -92,6 +102,7 @@ class NotificationSettings extends Equatable {
         title: title,
         body: body,
         stopButton: stopButton,
+        snoozeButton: snoozeButton,
         icon: icon,
         iconColorAlpha: iconColor?.a,
         iconColorRed: iconColor?.r,
@@ -106,6 +117,7 @@ class NotificationSettings extends Equatable {
     String? title,
     String? body,
     String? stopButton,
+    String? snoozeButton,
     String? icon,
     Color? iconColor,
     bool? keepNotificationAfterAlarmEnds,
@@ -114,6 +126,7 @@ class NotificationSettings extends Equatable {
       title: title ?? this.title,
       body: body ?? this.body,
       stopButton: stopButton ?? this.stopButton,
+      snoozeButton: snoozeButton ?? this.snoozeButton,
       icon: icon ?? this.icon,
       iconColor: iconColor ?? this.iconColor,
       keepNotificationAfterAlarmEnds:
@@ -126,6 +139,7 @@ class NotificationSettings extends Equatable {
         title,
         body,
         stopButton,
+        snoozeButton,
         icon,
         iconColor,
         keepNotificationAfterAlarmEnds,

--- a/lib/model/notification_settings.dart
+++ b/lib/model/notification_settings.dart
@@ -16,7 +16,7 @@ class NotificationSettings extends Equatable {
     required this.title,
     required this.body,
     this.stopButton,
-    this.snoozeButton,
+    this.androidSnoozeButton,
     this.icon,
     this.iconColor,
     this.keepNotificationAfterAlarmEnds = false,
@@ -45,7 +45,7 @@ class NotificationSettings extends Equatable {
   /// can perform.
   ///
   /// If null, button will not be shown. Null by default.
-  final String? snoozeButton;
+  final String? androidSnoozeButton;
 
   /// The icon to display on the notification.
   ///
@@ -103,7 +103,7 @@ class NotificationSettings extends Equatable {
         title: title,
         body: body,
         stopButton: stopButton,
-        snoozeButton: snoozeButton,
+        androidSnoozeButton: androidSnoozeButton,
         icon: icon,
         iconColorAlpha: iconColor?.a,
         iconColorRed: iconColor?.r,
@@ -118,7 +118,7 @@ class NotificationSettings extends Equatable {
     String? title,
     String? body,
     String? stopButton,
-    String? snoozeButton,
+    String? androidSnoozeButton,
     String? icon,
     Color? iconColor,
     bool? keepNotificationAfterAlarmEnds,
@@ -127,7 +127,7 @@ class NotificationSettings extends Equatable {
       title: title ?? this.title,
       body: body ?? this.body,
       stopButton: stopButton ?? this.stopButton,
-      snoozeButton: snoozeButton ?? this.snoozeButton,
+      androidSnoozeButton: androidSnoozeButton ?? this.androidSnoozeButton,
       icon: icon ?? this.icon,
       iconColor: iconColor ?? this.iconColor,
       keepNotificationAfterAlarmEnds:
@@ -140,7 +140,7 @@ class NotificationSettings extends Equatable {
         title,
         body,
         stopButton,
-        snoozeButton,
+        androidSnoozeButton,
         icon,
         iconColor,
         keepNotificationAfterAlarmEnds,

--- a/lib/model/notification_settings.g.dart
+++ b/lib/model/notification_settings.g.dart
@@ -16,7 +16,8 @@ NotificationSettings _$NotificationSettingsFromJson(
           title: $checkedConvert('title', (v) => v as String),
           body: $checkedConvert('body', (v) => v as String),
           stopButton: $checkedConvert('stopButton', (v) => v as String?),
-          snoozeButton: $checkedConvert('snoozeButton', (v) => v as String?),
+          androidSnoozeButton:
+              $checkedConvert('androidSnoozeButton', (v) => v as String?),
           icon: $checkedConvert('icon', (v) => v as String?),
           iconColor: $checkedConvert(
               'iconColor',
@@ -35,7 +36,8 @@ Map<String, dynamic> _$NotificationSettingsToJson(
       'title': instance.title,
       'body': instance.body,
       if (instance.stopButton case final value?) 'stopButton': value,
-      if (instance.snoozeButton case final value?) 'snoozeButton': value,
+      if (instance.androidSnoozeButton case final value?)
+        'androidSnoozeButton': value,
       if (instance.icon case final value?) 'icon': value,
       if (const _ColorJsonConverter().toJson(instance.iconColor)
           case final value?)

--- a/lib/model/notification_settings.g.dart
+++ b/lib/model/notification_settings.g.dart
@@ -16,6 +16,7 @@ NotificationSettings _$NotificationSettingsFromJson(
           title: $checkedConvert('title', (v) => v as String),
           body: $checkedConvert('body', (v) => v as String),
           stopButton: $checkedConvert('stopButton', (v) => v as String?),
+          snoozeButton: $checkedConvert('snoozeButton', (v) => v as String?),
           icon: $checkedConvert('icon', (v) => v as String?),
           iconColor: $checkedConvert(
               'iconColor',
@@ -37,6 +38,7 @@ Map<String, dynamic> _$NotificationSettingsToJson(
       'title': instance.title,
       'body': instance.body,
       if (instance.stopButton case final value?) 'stopButton': value,
+      if (instance.snoozeButton case final value?) 'snoozeButton': value,
       if (instance.icon case final value?) 'icon': value,
       if (instance.iconColor case final value?) 'iconColor': value.value,
       'keepNotificationAfterAlarmEnds': instance.keepNotificationAfterAlarmEnds,

--- a/lib/service/alarm_storage.dart
+++ b/lib/service/alarm_storage.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:alarm/model/alarm_settings.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_fgbg/flutter_fgbg.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -115,5 +116,17 @@ class AlarmStorage {
   static void dispose() {
     _fgbgSubscription?.cancel();
     _fgbgSubscription = null;
+  }
+
+  /// Forgets the initialized preferences so the next [init] runs again.
+  ///
+  /// Only for tests: `SharedPreferences.setMockInitialValues` swaps the
+  /// platform store, but this class holds a `SharedPreferences` instance with
+  /// its own populated cache, so without this a mocked store from one test is
+  /// invisible and the previous test's alarms leak into the next.
+  @visibleForTesting
+  static void resetForTesting() {
+    dispose();
+    _initFuture = null;
   }
 }

--- a/lib/src/alarm_trigger_api_impl.dart
+++ b/lib/src/alarm_trigger_api_impl.dart
@@ -8,13 +8,18 @@ typedef AlarmRangCallback = void Function(AlarmSettings alarm);
 /// Callback that is called when an alarm is stopped.
 typedef AlarmStoppedCallback = void Function(int alarmId);
 
+/// Callback that is called when an alarm is deferred on the host side.
+typedef AlarmSnoozedCallback = void Function(int alarmId, DateTime nextRingAt);
+
 /// Implements the API that handles calls coming from the host platform.
 class AlarmTriggerApiImpl extends AlarmTriggerApi {
   AlarmTriggerApiImpl._({
     required AlarmRangCallback alarmRang,
     required AlarmStoppedCallback alarmStopped,
+    required AlarmSnoozedCallback alarmSnoozed,
   })  : _alarmRang = alarmRang,
         _alarmStopped = alarmStopped,
+        _alarmSnoozed = alarmSnoozed,
         super() {
     AlarmTriggerApi.setUp(this);
   }
@@ -28,15 +33,19 @@ class AlarmTriggerApiImpl extends AlarmTriggerApi {
 
   final AlarmStoppedCallback _alarmStopped;
 
+  final AlarmSnoozedCallback _alarmSnoozed;
+
   /// Ensures that this Dart isolate is listening for method calls that may come
   /// from the host platform.
   static void ensureInitialized({
     required AlarmRangCallback alarmRang,
     required AlarmStoppedCallback alarmStopped,
+    required AlarmSnoozedCallback alarmSnoozed,
   }) {
     _instance ??= AlarmTriggerApiImpl._(
       alarmRang: alarmRang,
       alarmStopped: alarmStopped,
+      alarmSnoozed: alarmSnoozed,
     );
   }
 
@@ -57,5 +66,13 @@ class AlarmTriggerApiImpl extends AlarmTriggerApi {
   Future<void> alarmStopped(int alarmId) async {
     _log.info('Alarm with id $alarmId stopped.');
     _alarmStopped(alarmId);
+  }
+
+  @override
+  Future<void> alarmSnoozed(int alarmId, int millisecondsSinceEpoch) async {
+    final nextRingAt =
+        DateTime.fromMillisecondsSinceEpoch(millisecondsSinceEpoch);
+    _log.info('Alarm with id $alarmId snoozed until $nextRingAt.');
+    _alarmSnoozed(alarmId, nextRingAt);
   }
 }

--- a/lib/src/alarm_trigger_api_impl.dart
+++ b/lib/src/alarm_trigger_api_impl.dart
@@ -9,7 +9,13 @@ typedef AlarmRangCallback = void Function(AlarmSettings alarm);
 typedef AlarmStoppedCallback = void Function(int alarmId);
 
 /// Callback that is called when an alarm is deferred on the host side.
-typedef AlarmSnoozedCallback = void Function(int alarmId, DateTime nextRingAt);
+///
+/// Returns a future the host awaits before treating the deferral as observed,
+/// so it must not complete until the new time is durably stored.
+typedef AlarmSnoozedCallback = Future<void> Function(
+  int alarmId,
+  DateTime nextRingAt,
+);
 
 /// Implements the API that handles calls coming from the host platform.
 class AlarmTriggerApiImpl extends AlarmTriggerApi {
@@ -73,6 +79,9 @@ class AlarmTriggerApiImpl extends AlarmTriggerApi {
     final nextRingAt =
         DateTime.fromMillisecondsSinceEpoch(millisecondsSinceEpoch);
     _log.info('Alarm with id $alarmId snoozed until $nextRingAt.');
-    _alarmSnoozed(alarmId, nextRingAt);
+    // Awaited so the reply to the host is sent only once Dart has persisted
+    // the new time. The host uses that reply to decide whether it can drop its
+    // own reconciliation marker.
+    await _alarmSnoozed(alarmId, nextRingAt);
   }
 }

--- a/lib/src/alarm_trigger_api_impl.dart
+++ b/lib/src/alarm_trigger_api_impl.dart
@@ -1,5 +1,6 @@
 import 'package:alarm/alarm.dart';
 import 'package:alarm/src/generated/platform_bindings.g.dart';
+import 'package:flutter/foundation.dart';
 import 'package:logging/logging.dart';
 
 /// Callback that is called when an alarm starts ringing.
@@ -40,6 +41,14 @@ class AlarmTriggerApiImpl extends AlarmTriggerApi {
   final AlarmStoppedCallback _alarmStopped;
 
   final AlarmSnoozedCallback _alarmSnoozed;
+
+  /// Forgets the cached instance so the next [ensureInitialized] rebuilds it.
+  ///
+  /// Only for tests: the instance is `??=`-guarded, so without this the
+  /// callbacks registered by the first test in a file are the ones every later
+  /// test keeps using.
+  @visibleForTesting
+  static void resetForTesting() => _instance = null;
 
   /// Ensures that this Dart isolate is listening for method calls that may come
   /// from the host platform.

--- a/lib/src/generated/platform_bindings.g.dart
+++ b/lib/src/generated/platform_bindings.g.dart
@@ -296,7 +296,7 @@ class NotificationSettingsWire {
     this.iconColorGreen,
     this.iconColorBlue,
     required this.keepNotificationAfterAlarmEnds,
-    this.snoozeButton,
+    this.androidSnoozeButton,
   });
 
   String title;
@@ -322,7 +322,7 @@ class NotificationSettingsWire {
   /// Only shown when [AlarmSettingsWire.androidSnoozeDurationMillis] also
   /// gives it a usable duration; a label alone describes nothing the platform
   /// can perform. Android only.
-  String? snoozeButton;
+  String? androidSnoozeButton;
 
   List<Object?> _toList() {
     return <Object?>[
@@ -335,7 +335,7 @@ class NotificationSettingsWire {
       iconColorGreen,
       iconColorBlue,
       keepNotificationAfterAlarmEnds,
-      snoozeButton,
+      androidSnoozeButton,
     ];
   }
 
@@ -355,7 +355,7 @@ class NotificationSettingsWire {
       iconColorGreen: result[6] as double?,
       iconColorBlue: result[7] as double?,
       keepNotificationAfterAlarmEnds: result[8]! as bool,
-      snoozeButton: result[9] as String?,
+      androidSnoozeButton: result[9] as String?,
     );
   }
 

--- a/lib/src/generated/platform_bindings.g.dart
+++ b/lib/src/generated/platform_bindings.g.dart
@@ -15,7 +15,8 @@ PlatformException _createConnectionError(String channelName) {
   );
 }
 
-List<Object?> wrapResponse({Object? result, PlatformException? error, bool empty = false}) {
+List<Object?> wrapResponse(
+    {Object? result, PlatformException? error, bool empty = false}) {
   if (empty) {
     return <Object?>[];
   }
@@ -24,30 +25,35 @@ List<Object?> wrapResponse({Object? result, PlatformException? error, bool empty
   }
   return <Object?>[error.code, error.message, error.details];
 }
+
 bool _deepEquals(Object? a, Object? b) {
   if (a is List && b is List) {
     return a.length == b.length &&
         a.indexed
-        .every(((int, dynamic) item) => _deepEquals(item.$2, b[item.$1]));
+            .every(((int, dynamic) item) => _deepEquals(item.$2, b[item.$1]));
   }
   if (a is Map && b is Map) {
-    return a.length == b.length && a.entries.every((MapEntry<Object?, Object?> entry) =>
-        (b as Map<Object?, Object?>).containsKey(entry.key) &&
-        _deepEquals(entry.value, b[entry.key]));
+    return a.length == b.length &&
+        a.entries.every((MapEntry<Object?, Object?> entry) =>
+            (b as Map<Object?, Object?>).containsKey(entry.key) &&
+            _deepEquals(entry.value, b[entry.key]));
   }
   return a == b;
 }
 
-
 /// Errors that can occur when interacting with the Alarm API.
 enum AlarmErrorCode {
   unknown,
+
   /// A plugin internal error. Please report these as bugs on GitHub.
   pluginInternal,
+
   /// The arguments passed to the method are invalid.
   invalidArguments,
+
   /// An error occurred while communicating with the native platform.
   channelError,
+
   /// The required notification permission was not granted.
   ///
   /// Please use an external permission manager such as "permission_handler" to
@@ -71,7 +77,7 @@ class AlarmSettingsWire {
     required this.iOSBackgroundAudio,
     required this.androidStopAlarmOnTermination,
     required this.preferConnectedAudioDevice,
-    this.androidSnoozeDurationSeconds,
+    this.androidSnoozeDurationMillis,
   });
 
   int id;
@@ -102,10 +108,13 @@ class AlarmSettingsWire {
 
   bool preferConnectedAudioDevice;
 
-  /// How long the snooze action defers the alarm, in seconds.
+  /// How long the snooze action defers the alarm, in milliseconds.
   ///
-  /// Null, or anything below one, offers no snooze. Android only.
-  int? androidSnoozeDurationSeconds;
+  /// Null, or anything below one minute, offers no snooze. The floor exists
+  /// because Android scheduling falls back to a plain `Handler.postDelayed`
+  /// below a few seconds, which survives neither process death nor
+  /// cancellation. Android only.
+  int? androidSnoozeDurationMillis;
 
   List<Object?> _toList() {
     return <Object?>[
@@ -123,12 +132,13 @@ class AlarmSettingsWire {
       iOSBackgroundAudio,
       androidStopAlarmOnTermination,
       preferConnectedAudioDevice,
-      androidSnoozeDurationSeconds,
+      androidSnoozeDurationMillis,
     ];
   }
 
   Object encode() {
-    return _toList();  }
+    return _toList();
+  }
 
   static AlarmSettingsWire decode(Object result) {
     result as List<Object?>;
@@ -147,7 +157,7 @@ class AlarmSettingsWire {
       iOSBackgroundAudio: result[11]! as bool,
       androidStopAlarmOnTermination: result[12]! as bool,
       preferConnectedAudioDevice: result[13]! as bool,
-      androidSnoozeDurationSeconds: result[14] as int?,
+      androidSnoozeDurationMillis: result[14] as int?,
     );
   }
 
@@ -165,8 +175,7 @@ class AlarmSettingsWire {
 
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
-  int get hashCode => Object.hashAll(_toList())
-;
+  int get hashCode => Object.hashAll(_toList());
 }
 
 class VolumeSettingsWire {
@@ -199,7 +208,8 @@ class VolumeSettingsWire {
   }
 
   Object encode() {
-    return _toList();  }
+    return _toList();
+  }
 
   static VolumeSettingsWire decode(Object result) {
     result as List<Object?>;
@@ -226,8 +236,7 @@ class VolumeSettingsWire {
 
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
-  int get hashCode => Object.hashAll(_toList())
-;
+  int get hashCode => Object.hashAll(_toList());
 }
 
 class VolumeFadeStepWire {
@@ -248,7 +257,8 @@ class VolumeFadeStepWire {
   }
 
   Object encode() {
-    return _toList();  }
+    return _toList();
+  }
 
   static VolumeFadeStepWire decode(Object result) {
     result as List<Object?>;
@@ -272,8 +282,7 @@ class VolumeFadeStepWire {
 
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
-  int get hashCode => Object.hashAll(_toList())
-;
+  int get hashCode => Object.hashAll(_toList());
 }
 
 class NotificationSettingsWire {
@@ -310,9 +319,9 @@ class NotificationSettingsWire {
 
   /// Label for the snooze action. Null omits the action.
   ///
-  /// Only shown when [AlarmSettingsWire.androidSnoozeDurationSeconds] also
-  /// gives it a duration; a label alone describes nothing the platform can
-  /// perform. Android only.
+  /// Only shown when [AlarmSettingsWire.androidSnoozeDurationMillis] also
+  /// gives it a usable duration; a label alone describes nothing the platform
+  /// can perform. Android only.
   String? snoozeButton;
 
   List<Object?> _toList() {
@@ -331,7 +340,8 @@ class NotificationSettingsWire {
   }
 
   Object encode() {
-    return _toList();  }
+    return _toList();
+  }
 
   static NotificationSettingsWire decode(Object result) {
     result as List<Object?>;
@@ -352,7 +362,8 @@ class NotificationSettingsWire {
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
   bool operator ==(Object other) {
-    if (other is! NotificationSettingsWire || other.runtimeType != runtimeType) {
+    if (other is! NotificationSettingsWire ||
+        other.runtimeType != runtimeType) {
       return false;
     }
     if (identical(this, other)) {
@@ -363,13 +374,12 @@ class NotificationSettingsWire {
 
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
-  int get hashCode => Object.hashAll(_toList())
-;
+  int get hashCode => Object.hashAll(_toList());
 }
 
-/// One deferral taken on the host side.
-class SnoozedAlarmWire {
-  SnoozedAlarmWire({
+/// A snooze the host recorded and Dart has not yet applied.
+class PendingSnoozeWire {
+  PendingSnoozeWire({
     required this.alarmId,
     required this.millisecondsSinceEpoch,
   });
@@ -386,11 +396,12 @@ class SnoozedAlarmWire {
   }
 
   Object encode() {
-    return _toList();  }
+    return _toList();
+  }
 
-  static SnoozedAlarmWire decode(Object result) {
+  static PendingSnoozeWire decode(Object result) {
     result as List<Object?>;
-    return SnoozedAlarmWire(
+    return PendingSnoozeWire(
       alarmId: result[0]! as int,
       millisecondsSinceEpoch: result[1]! as int,
     );
@@ -399,7 +410,7 @@ class SnoozedAlarmWire {
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
   bool operator ==(Object other) {
-    if (other is! SnoozedAlarmWire || other.runtimeType != runtimeType) {
+    if (other is! PendingSnoozeWire || other.runtimeType != runtimeType) {
       return false;
     }
     if (identical(this, other)) {
@@ -410,10 +421,8 @@ class SnoozedAlarmWire {
 
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
-  int get hashCode => Object.hashAll(_toList())
-;
+  int get hashCode => Object.hashAll(_toList());
 }
-
 
 class _PigeonCodec extends StandardMessageCodec {
   const _PigeonCodec();
@@ -422,22 +431,22 @@ class _PigeonCodec extends StandardMessageCodec {
     if (value is int) {
       buffer.putUint8(4);
       buffer.putInt64(value);
-    }    else if (value is AlarmErrorCode) {
+    } else if (value is AlarmErrorCode) {
       buffer.putUint8(129);
       writeValue(buffer, value.index);
-    }    else if (value is AlarmSettingsWire) {
+    } else if (value is AlarmSettingsWire) {
       buffer.putUint8(130);
       writeValue(buffer, value.encode());
-    }    else if (value is VolumeSettingsWire) {
+    } else if (value is VolumeSettingsWire) {
       buffer.putUint8(131);
       writeValue(buffer, value.encode());
-    }    else if (value is VolumeFadeStepWire) {
+    } else if (value is VolumeFadeStepWire) {
       buffer.putUint8(132);
       writeValue(buffer, value.encode());
-    }    else if (value is NotificationSettingsWire) {
+    } else if (value is NotificationSettingsWire) {
       buffer.putUint8(133);
       writeValue(buffer, value.encode());
-    }    else if (value is SnoozedAlarmWire) {
+    } else if (value is PendingSnoozeWire) {
       buffer.putUint8(134);
       writeValue(buffer, value.encode());
     } else {
@@ -448,19 +457,19 @@ class _PigeonCodec extends StandardMessageCodec {
   @override
   Object? readValueOfType(int type, ReadBuffer buffer) {
     switch (type) {
-      case 129: 
+      case 129:
         final int? value = readValue(buffer) as int?;
         return value == null ? null : AlarmErrorCode.values[value];
-      case 130: 
+      case 130:
         return AlarmSettingsWire.decode(readValue(buffer)!);
-      case 131: 
+      case 131:
         return VolumeSettingsWire.decode(readValue(buffer)!);
-      case 132: 
+      case 132:
         return VolumeFadeStepWire.decode(readValue(buffer)!);
-      case 133: 
+      case 133:
         return NotificationSettingsWire.decode(readValue(buffer)!);
-      case 134: 
-        return SnoozedAlarmWire.decode(readValue(buffer)!);
+      case 134:
+        return PendingSnoozeWire.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);
     }
@@ -473,7 +482,8 @@ class AlarmApi {
   /// BinaryMessenger will be used which routes to the host platform.
   AlarmApi({BinaryMessenger? binaryMessenger, String messageChannelSuffix = ''})
       : pigeonVar_binaryMessenger = binaryMessenger,
-        pigeonVar_messageChannelSuffix = messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
+        pigeonVar_messageChannelSuffix =
+            messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
   final BinaryMessenger? pigeonVar_binaryMessenger;
 
   static const MessageCodec<Object?> pigeonChannelCodec = _PigeonCodec();
@@ -481,13 +491,16 @@ class AlarmApi {
   final String pigeonVar_messageChannelSuffix;
 
   Future<void> setAlarm({required AlarmSettingsWire alarmSettings}) async {
-    final String pigeonVar_channelName = 'dev.flutter.pigeon.alarm.AlarmApi.setAlarm$pigeonVar_messageChannelSuffix';
-    final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
+    final String pigeonVar_channelName =
+        'dev.flutter.pigeon.alarm.AlarmApi.setAlarm$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel =
+        BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[alarmSettings]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[alarmSettings]);
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -504,13 +517,16 @@ class AlarmApi {
   }
 
   Future<void> stopAlarm({required int alarmId}) async {
-    final String pigeonVar_channelName = 'dev.flutter.pigeon.alarm.AlarmApi.stopAlarm$pigeonVar_messageChannelSuffix';
-    final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
+    final String pigeonVar_channelName =
+        'dev.flutter.pigeon.alarm.AlarmApi.stopAlarm$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel =
+        BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[alarmId]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[alarmId]);
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -527,8 +543,10 @@ class AlarmApi {
   }
 
   Future<void> stopAll() async {
-    final String pigeonVar_channelName = 'dev.flutter.pigeon.alarm.AlarmApi.stopAll$pigeonVar_messageChannelSuffix';
-    final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
+    final String pigeonVar_channelName =
+        'dev.flutter.pigeon.alarm.AlarmApi.stopAll$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel =
+        BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
@@ -550,13 +568,16 @@ class AlarmApi {
   }
 
   Future<bool> isRinging({required int? alarmId}) async {
-    final String pigeonVar_channelName = 'dev.flutter.pigeon.alarm.AlarmApi.isRinging$pigeonVar_messageChannelSuffix';
-    final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
+    final String pigeonVar_channelName =
+        'dev.flutter.pigeon.alarm.AlarmApi.isRinging$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel =
+        BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[alarmId]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[alarmId]);
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -577,14 +598,18 @@ class AlarmApi {
     }
   }
 
-  Future<void> setWarningNotificationOnKill({required String title, required String body}) async {
-    final String pigeonVar_channelName = 'dev.flutter.pigeon.alarm.AlarmApi.setWarningNotificationOnKill$pigeonVar_messageChannelSuffix';
-    final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
+  Future<void> setWarningNotificationOnKill(
+      {required String title, required String body}) async {
+    final String pigeonVar_channelName =
+        'dev.flutter.pigeon.alarm.AlarmApi.setWarningNotificationOnKill$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel =
+        BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[title, body]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[title, body]);
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -601,8 +626,10 @@ class AlarmApi {
   }
 
   Future<void> disableWarningNotificationOnKill() async {
-    final String pigeonVar_channelName = 'dev.flutter.pigeon.alarm.AlarmApi.disableWarningNotificationOnKill$pigeonVar_messageChannelSuffix';
-    final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
+    final String pigeonVar_channelName =
+        'dev.flutter.pigeon.alarm.AlarmApi.disableWarningNotificationOnKill$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel =
+        BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
@@ -623,17 +650,21 @@ class AlarmApi {
     }
   }
 
-  /// Drains the snoozes taken on the host side that no Dart isolate has
-  /// observed yet.
+  /// Lists snoozes the host has recorded but Dart has not yet applied.
   ///
-  /// A snooze is normally taken with no engine running: the notification and
-  /// the ringing screen are native, and a full screen intent starts the
-  /// process without starting Flutter. [AlarmTriggerApi.alarmSnoozed] reaches
-  /// nobody in that case, so the deferral is held until an isolate collects
-  /// it. Draining is destructive; a collected snooze is not reported twice.
-  Future<List<SnoozedAlarmWire>> takeUnreportedSnoozes() async {
-    final String pigeonVar_channelName = 'dev.flutter.pigeon.alarm.AlarmApi.takeUnreportedSnoozes$pigeonVar_messageChannelSuffix';
-    final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
+  /// A snooze is normally taken with no engine running: the notification is
+  /// native and a full screen intent starts the process without starting
+  /// Flutter, so [AlarmTriggerApi.alarmSnoozed] reaches nobody. The host holds
+  /// a marker until Dart has durably applied it.
+  ///
+  /// Reading is **not** destructive — the marker survives until
+  /// [acknowledgeSnooze] confirms Dart wrote the new time. A read that is
+  /// followed by a crash therefore loses nothing.
+  Future<List<PendingSnoozeWire>> getPendingSnoozes() async {
+    final String pigeonVar_channelName =
+        'dev.flutter.pigeon.alarm.AlarmApi.getPendingSnoozes$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel =
+        BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
@@ -655,7 +686,41 @@ class AlarmApi {
         message: 'Host platform returned null value for non-null return value.',
       );
     } else {
-      return (pigeonVar_replyList[0] as List<Object?>?)!.cast<SnoozedAlarmWire>();
+      return (pigeonVar_replyList[0] as List<Object?>?)!
+          .cast<PendingSnoozeWire>();
+    }
+  }
+
+  /// Drops the marker for [alarmId], but only if it still records exactly
+  /// [nextRingAtMillis].
+  ///
+  /// Matching on the timestamp as well as the id means a late acknowledgement
+  /// for an earlier snooze cannot discard a newer one taken for the same
+  /// alarm in the meantime.
+  Future<void> acknowledgeSnooze(
+      {required int alarmId, required int nextRingAtMillis}) async {
+    final String pigeonVar_channelName =
+        'dev.flutter.pigeon.alarm.AlarmApi.acknowledgeSnooze$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel =
+        BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[alarmId, nextRingAtMillis]);
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
+    if (pigeonVar_replyList == null) {
+      throw _createConnectionError(pigeonVar_channelName);
+    } else if (pigeonVar_replyList.length > 1) {
+      throw PlatformException(
+        code: pigeonVar_replyList[0]! as String,
+        message: pigeonVar_replyList[1] as String?,
+        details: pigeonVar_replyList[2],
+      );
+    } else {
+      return;
     }
   }
 }
@@ -675,18 +740,26 @@ abstract class AlarmTriggerApi {
   /// they asked to be reminded of again.
   Future<void> alarmSnoozed(int alarmId, int millisecondsSinceEpoch);
 
-  static void setUp(AlarmTriggerApi? api, {BinaryMessenger? binaryMessenger, String messageChannelSuffix = '',}) {
-    messageChannelSuffix = messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
+  static void setUp(
+    AlarmTriggerApi? api, {
+    BinaryMessenger? binaryMessenger,
+    String messageChannelSuffix = '',
+  }) {
+    messageChannelSuffix =
+        messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
     {
-      final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.alarm.AlarmTriggerApi.alarmRang$messageChannelSuffix', pigeonChannelCodec,
+      final BasicMessageChannel<
+          Object?> pigeonVar_channel = BasicMessageChannel<
+              Object?>(
+          'dev.flutter.pigeon.alarm.AlarmTriggerApi.alarmRang$messageChannelSuffix',
+          pigeonChannelCodec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
           assert(message != null,
-          'Argument for dev.flutter.pigeon.alarm.AlarmTriggerApi.alarmRang was null.');
+              'Argument for dev.flutter.pigeon.alarm.AlarmTriggerApi.alarmRang was null.');
           final List<Object?> args = (message as List<Object?>?)!;
           final int? arg_alarmId = (args[0] as int?);
           assert(arg_alarmId != null,
@@ -696,22 +769,26 @@ abstract class AlarmTriggerApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          }          catch (e) {
-            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
+          } catch (e) {
+            return wrapResponse(
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
-      final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.alarm.AlarmTriggerApi.alarmStopped$messageChannelSuffix', pigeonChannelCodec,
+      final BasicMessageChannel<
+          Object?> pigeonVar_channel = BasicMessageChannel<
+              Object?>(
+          'dev.flutter.pigeon.alarm.AlarmTriggerApi.alarmStopped$messageChannelSuffix',
+          pigeonChannelCodec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
           assert(message != null,
-          'Argument for dev.flutter.pigeon.alarm.AlarmTriggerApi.alarmStopped was null.');
+              'Argument for dev.flutter.pigeon.alarm.AlarmTriggerApi.alarmStopped was null.');
           final List<Object?> args = (message as List<Object?>?)!;
           final int? arg_alarmId = (args[0] as int?);
           assert(arg_alarmId != null,
@@ -721,22 +798,26 @@ abstract class AlarmTriggerApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          }          catch (e) {
-            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
+          } catch (e) {
+            return wrapResponse(
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
-      final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.alarm.AlarmTriggerApi.alarmSnoozed$messageChannelSuffix', pigeonChannelCodec,
+      final BasicMessageChannel<
+          Object?> pigeonVar_channel = BasicMessageChannel<
+              Object?>(
+          'dev.flutter.pigeon.alarm.AlarmTriggerApi.alarmSnoozed$messageChannelSuffix',
+          pigeonChannelCodec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
           assert(message != null,
-          'Argument for dev.flutter.pigeon.alarm.AlarmTriggerApi.alarmSnoozed was null.');
+              'Argument for dev.flutter.pigeon.alarm.AlarmTriggerApi.alarmSnoozed was null.');
           final List<Object?> args = (message as List<Object?>?)!;
           final int? arg_alarmId = (args[0] as int?);
           assert(arg_alarmId != null,
@@ -749,8 +830,9 @@ abstract class AlarmTriggerApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          }          catch (e) {
-            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
+          } catch (e) {
+            return wrapResponse(
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }

--- a/lib/src/generated/platform_bindings.g.dart
+++ b/lib/src/generated/platform_bindings.g.dart
@@ -15,8 +15,7 @@ PlatformException _createConnectionError(String channelName) {
   );
 }
 
-List<Object?> wrapResponse(
-    {Object? result, PlatformException? error, bool empty = false}) {
+List<Object?> wrapResponse({Object? result, PlatformException? error, bool empty = false}) {
   if (empty) {
     return <Object?>[];
   }
@@ -25,35 +24,30 @@ List<Object?> wrapResponse(
   }
   return <Object?>[error.code, error.message, error.details];
 }
-
 bool _deepEquals(Object? a, Object? b) {
   if (a is List && b is List) {
     return a.length == b.length &&
         a.indexed
-            .every(((int, dynamic) item) => _deepEquals(item.$2, b[item.$1]));
+        .every(((int, dynamic) item) => _deepEquals(item.$2, b[item.$1]));
   }
   if (a is Map && b is Map) {
-    return a.length == b.length &&
-        a.entries.every((MapEntry<Object?, Object?> entry) =>
-            (b as Map<Object?, Object?>).containsKey(entry.key) &&
-            _deepEquals(entry.value, b[entry.key]));
+    return a.length == b.length && a.entries.every((MapEntry<Object?, Object?> entry) =>
+        (b as Map<Object?, Object?>).containsKey(entry.key) &&
+        _deepEquals(entry.value, b[entry.key]));
   }
   return a == b;
 }
 
+
 /// Errors that can occur when interacting with the Alarm API.
 enum AlarmErrorCode {
   unknown,
-
   /// A plugin internal error. Please report these as bugs on GitHub.
   pluginInternal,
-
   /// The arguments passed to the method are invalid.
   invalidArguments,
-
   /// An error occurred while communicating with the native platform.
   channelError,
-
   /// The required notification permission was not granted.
   ///
   /// Please use an external permission manager such as "permission_handler" to
@@ -77,6 +71,7 @@ class AlarmSettingsWire {
     required this.iOSBackgroundAudio,
     required this.androidStopAlarmOnTermination,
     required this.preferConnectedAudioDevice,
+    this.androidSnoozeDurationSeconds,
   });
 
   int id;
@@ -107,6 +102,11 @@ class AlarmSettingsWire {
 
   bool preferConnectedAudioDevice;
 
+  /// How long the snooze action defers the alarm, in seconds.
+  ///
+  /// Null, or anything below one, offers no snooze. Android only.
+  int? androidSnoozeDurationSeconds;
+
   List<Object?> _toList() {
     return <Object?>[
       id,
@@ -123,12 +123,12 @@ class AlarmSettingsWire {
       iOSBackgroundAudio,
       androidStopAlarmOnTermination,
       preferConnectedAudioDevice,
+      androidSnoozeDurationSeconds,
     ];
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static AlarmSettingsWire decode(Object result) {
     result as List<Object?>;
@@ -147,6 +147,7 @@ class AlarmSettingsWire {
       iOSBackgroundAudio: result[11]! as bool,
       androidStopAlarmOnTermination: result[12]! as bool,
       preferConnectedAudioDevice: result[13]! as bool,
+      androidSnoozeDurationSeconds: result[14] as int?,
     );
   }
 
@@ -164,7 +165,8 @@ class AlarmSettingsWire {
 
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
-  int get hashCode => Object.hashAll(_toList());
+  int get hashCode => Object.hashAll(_toList())
+;
 }
 
 class VolumeSettingsWire {
@@ -197,8 +199,7 @@ class VolumeSettingsWire {
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static VolumeSettingsWire decode(Object result) {
     result as List<Object?>;
@@ -225,7 +226,8 @@ class VolumeSettingsWire {
 
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
-  int get hashCode => Object.hashAll(_toList());
+  int get hashCode => Object.hashAll(_toList())
+;
 }
 
 class VolumeFadeStepWire {
@@ -246,8 +248,7 @@ class VolumeFadeStepWire {
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static VolumeFadeStepWire decode(Object result) {
     result as List<Object?>;
@@ -271,7 +272,8 @@ class VolumeFadeStepWire {
 
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
-  int get hashCode => Object.hashAll(_toList());
+  int get hashCode => Object.hashAll(_toList())
+;
 }
 
 class NotificationSettingsWire {
@@ -285,6 +287,7 @@ class NotificationSettingsWire {
     this.iconColorGreen,
     this.iconColorBlue,
     required this.keepNotificationAfterAlarmEnds,
+    this.snoozeButton,
   });
 
   String title;
@@ -305,6 +308,13 @@ class NotificationSettingsWire {
 
   bool keepNotificationAfterAlarmEnds;
 
+  /// Label for the snooze action. Null omits the action.
+  ///
+  /// Only shown when [AlarmSettingsWire.androidSnoozeDurationSeconds] also
+  /// gives it a duration; a label alone describes nothing the platform can
+  /// perform. Android only.
+  String? snoozeButton;
+
   List<Object?> _toList() {
     return <Object?>[
       title,
@@ -316,12 +326,12 @@ class NotificationSettingsWire {
       iconColorGreen,
       iconColorBlue,
       keepNotificationAfterAlarmEnds,
+      snoozeButton,
     ];
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static NotificationSettingsWire decode(Object result) {
     result as List<Object?>;
@@ -335,14 +345,14 @@ class NotificationSettingsWire {
       iconColorGreen: result[6] as double?,
       iconColorBlue: result[7] as double?,
       keepNotificationAfterAlarmEnds: result[8]! as bool,
+      snoozeButton: result[9] as String?,
     );
   }
 
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
   bool operator ==(Object other) {
-    if (other is! NotificationSettingsWire ||
-        other.runtimeType != runtimeType) {
+    if (other is! NotificationSettingsWire || other.runtimeType != runtimeType) {
       return false;
     }
     if (identical(this, other)) {
@@ -353,8 +363,57 @@ class NotificationSettingsWire {
 
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
-  int get hashCode => Object.hashAll(_toList());
+  int get hashCode => Object.hashAll(_toList())
+;
 }
+
+/// One deferral taken on the host side.
+class SnoozedAlarmWire {
+  SnoozedAlarmWire({
+    required this.alarmId,
+    required this.millisecondsSinceEpoch,
+  });
+
+  int alarmId;
+
+  int millisecondsSinceEpoch;
+
+  List<Object?> _toList() {
+    return <Object?>[
+      alarmId,
+      millisecondsSinceEpoch,
+    ];
+  }
+
+  Object encode() {
+    return _toList();  }
+
+  static SnoozedAlarmWire decode(Object result) {
+    result as List<Object?>;
+    return SnoozedAlarmWire(
+      alarmId: result[0]! as int,
+      millisecondsSinceEpoch: result[1]! as int,
+    );
+  }
+
+  @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  bool operator ==(Object other) {
+    if (other is! SnoozedAlarmWire || other.runtimeType != runtimeType) {
+      return false;
+    }
+    if (identical(this, other)) {
+      return true;
+    }
+    return _deepEquals(encode(), other.encode());
+  }
+
+  @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  int get hashCode => Object.hashAll(_toList())
+;
+}
+
 
 class _PigeonCodec extends StandardMessageCodec {
   const _PigeonCodec();
@@ -363,20 +422,23 @@ class _PigeonCodec extends StandardMessageCodec {
     if (value is int) {
       buffer.putUint8(4);
       buffer.putInt64(value);
-    } else if (value is AlarmErrorCode) {
+    }    else if (value is AlarmErrorCode) {
       buffer.putUint8(129);
       writeValue(buffer, value.index);
-    } else if (value is AlarmSettingsWire) {
+    }    else if (value is AlarmSettingsWire) {
       buffer.putUint8(130);
       writeValue(buffer, value.encode());
-    } else if (value is VolumeSettingsWire) {
+    }    else if (value is VolumeSettingsWire) {
       buffer.putUint8(131);
       writeValue(buffer, value.encode());
-    } else if (value is VolumeFadeStepWire) {
+    }    else if (value is VolumeFadeStepWire) {
       buffer.putUint8(132);
       writeValue(buffer, value.encode());
-    } else if (value is NotificationSettingsWire) {
+    }    else if (value is NotificationSettingsWire) {
       buffer.putUint8(133);
+      writeValue(buffer, value.encode());
+    }    else if (value is SnoozedAlarmWire) {
+      buffer.putUint8(134);
       writeValue(buffer, value.encode());
     } else {
       super.writeValue(buffer, value);
@@ -386,17 +448,19 @@ class _PigeonCodec extends StandardMessageCodec {
   @override
   Object? readValueOfType(int type, ReadBuffer buffer) {
     switch (type) {
-      case 129:
+      case 129: 
         final int? value = readValue(buffer) as int?;
         return value == null ? null : AlarmErrorCode.values[value];
-      case 130:
+      case 130: 
         return AlarmSettingsWire.decode(readValue(buffer)!);
-      case 131:
+      case 131: 
         return VolumeSettingsWire.decode(readValue(buffer)!);
-      case 132:
+      case 132: 
         return VolumeFadeStepWire.decode(readValue(buffer)!);
-      case 133:
+      case 133: 
         return NotificationSettingsWire.decode(readValue(buffer)!);
+      case 134: 
+        return SnoozedAlarmWire.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);
     }
@@ -409,8 +473,7 @@ class AlarmApi {
   /// BinaryMessenger will be used which routes to the host platform.
   AlarmApi({BinaryMessenger? binaryMessenger, String messageChannelSuffix = ''})
       : pigeonVar_binaryMessenger = binaryMessenger,
-        pigeonVar_messageChannelSuffix =
-            messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
+        pigeonVar_messageChannelSuffix = messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
   final BinaryMessenger? pigeonVar_binaryMessenger;
 
   static const MessageCodec<Object?> pigeonChannelCodec = _PigeonCodec();
@@ -418,16 +481,13 @@ class AlarmApi {
   final String pigeonVar_messageChannelSuffix;
 
   Future<void> setAlarm({required AlarmSettingsWire alarmSettings}) async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.alarm.AlarmApi.setAlarm$pigeonVar_messageChannelSuffix';
-    final BasicMessageChannel<Object?> pigeonVar_channel =
-        BasicMessageChannel<Object?>(
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.alarm.AlarmApi.setAlarm$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[alarmSettings]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[alarmSettings]);
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -444,16 +504,13 @@ class AlarmApi {
   }
 
   Future<void> stopAlarm({required int alarmId}) async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.alarm.AlarmApi.stopAlarm$pigeonVar_messageChannelSuffix';
-    final BasicMessageChannel<Object?> pigeonVar_channel =
-        BasicMessageChannel<Object?>(
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.alarm.AlarmApi.stopAlarm$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[alarmId]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[alarmId]);
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -470,10 +527,8 @@ class AlarmApi {
   }
 
   Future<void> stopAll() async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.alarm.AlarmApi.stopAll$pigeonVar_messageChannelSuffix';
-    final BasicMessageChannel<Object?> pigeonVar_channel =
-        BasicMessageChannel<Object?>(
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.alarm.AlarmApi.stopAll$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
@@ -495,16 +550,13 @@ class AlarmApi {
   }
 
   Future<bool> isRinging({required int? alarmId}) async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.alarm.AlarmApi.isRinging$pigeonVar_messageChannelSuffix';
-    final BasicMessageChannel<Object?> pigeonVar_channel =
-        BasicMessageChannel<Object?>(
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.alarm.AlarmApi.isRinging$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[alarmId]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[alarmId]);
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -525,18 +577,14 @@ class AlarmApi {
     }
   }
 
-  Future<void> setWarningNotificationOnKill(
-      {required String title, required String body}) async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.alarm.AlarmApi.setWarningNotificationOnKill$pigeonVar_messageChannelSuffix';
-    final BasicMessageChannel<Object?> pigeonVar_channel =
-        BasicMessageChannel<Object?>(
+  Future<void> setWarningNotificationOnKill({required String title, required String body}) async {
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.alarm.AlarmApi.setWarningNotificationOnKill$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[title, body]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[title, body]);
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -553,10 +601,8 @@ class AlarmApi {
   }
 
   Future<void> disableWarningNotificationOnKill() async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.alarm.AlarmApi.disableWarningNotificationOnKill$pigeonVar_messageChannelSuffix';
-    final BasicMessageChannel<Object?> pigeonVar_channel =
-        BasicMessageChannel<Object?>(
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.alarm.AlarmApi.disableWarningNotificationOnKill$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
@@ -576,6 +622,42 @@ class AlarmApi {
       return;
     }
   }
+
+  /// Drains the snoozes taken on the host side that no Dart isolate has
+  /// observed yet.
+  ///
+  /// A snooze is normally taken with no engine running: the notification and
+  /// the ringing screen are native, and a full screen intent starts the
+  /// process without starting Flutter. [AlarmTriggerApi.alarmSnoozed] reaches
+  /// nobody in that case, so the deferral is held until an isolate collects
+  /// it. Draining is destructive; a collected snooze is not reported twice.
+  Future<List<SnoozedAlarmWire>> takeUnreportedSnoozes() async {
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.alarm.AlarmApi.takeUnreportedSnoozes$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
+    if (pigeonVar_replyList == null) {
+      throw _createConnectionError(pigeonVar_channelName);
+    } else if (pigeonVar_replyList.length > 1) {
+      throw PlatformException(
+        code: pigeonVar_replyList[0]! as String,
+        message: pigeonVar_replyList[1] as String?,
+        details: pigeonVar_replyList[2],
+      );
+    } else if (pigeonVar_replyList[0] == null) {
+      throw PlatformException(
+        code: 'null-error',
+        message: 'Host platform returned null value for non-null return value.',
+      );
+    } else {
+      return (pigeonVar_replyList[0] as List<Object?>?)!.cast<SnoozedAlarmWire>();
+    }
+  }
 }
 
 abstract class AlarmTriggerApi {
@@ -585,26 +667,26 @@ abstract class AlarmTriggerApi {
 
   Future<void> alarmStopped(int alarmId);
 
-  static void setUp(
-    AlarmTriggerApi? api, {
-    BinaryMessenger? binaryMessenger,
-    String messageChannelSuffix = '',
-  }) {
-    messageChannelSuffix =
-        messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
+  /// An alarm was deferred on the host side and re-registered for
+  /// [millisecondsSinceEpoch].
+  ///
+  /// Distinct from [alarmStopped] because the alarm is still owed: reporting a
+  /// snooze as a stop would tell the application the user dismissed something
+  /// they asked to be reminded of again.
+  Future<void> alarmSnoozed(int alarmId, int millisecondsSinceEpoch);
+
+  static void setUp(AlarmTriggerApi? api, {BinaryMessenger? binaryMessenger, String messageChannelSuffix = '',}) {
+    messageChannelSuffix = messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
     {
-      final BasicMessageChannel<
-          Object?> pigeonVar_channel = BasicMessageChannel<
-              Object?>(
-          'dev.flutter.pigeon.alarm.AlarmTriggerApi.alarmRang$messageChannelSuffix',
-          pigeonChannelCodec,
+      final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.alarm.AlarmTriggerApi.alarmRang$messageChannelSuffix', pigeonChannelCodec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
           assert(message != null,
-              'Argument for dev.flutter.pigeon.alarm.AlarmTriggerApi.alarmRang was null.');
+          'Argument for dev.flutter.pigeon.alarm.AlarmTriggerApi.alarmRang was null.');
           final List<Object?> args = (message as List<Object?>?)!;
           final int? arg_alarmId = (args[0] as int?);
           assert(arg_alarmId != null,
@@ -614,26 +696,22 @@ abstract class AlarmTriggerApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
-      final BasicMessageChannel<
-          Object?> pigeonVar_channel = BasicMessageChannel<
-              Object?>(
-          'dev.flutter.pigeon.alarm.AlarmTriggerApi.alarmStopped$messageChannelSuffix',
-          pigeonChannelCodec,
+      final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.alarm.AlarmTriggerApi.alarmStopped$messageChannelSuffix', pigeonChannelCodec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
           assert(message != null,
-              'Argument for dev.flutter.pigeon.alarm.AlarmTriggerApi.alarmStopped was null.');
+          'Argument for dev.flutter.pigeon.alarm.AlarmTriggerApi.alarmStopped was null.');
           final List<Object?> args = (message as List<Object?>?)!;
           final int? arg_alarmId = (args[0] as int?);
           assert(arg_alarmId != null,
@@ -643,9 +721,36 @@ abstract class AlarmTriggerApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
+          }
+        });
+      }
+    }
+    {
+      final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.alarm.AlarmTriggerApi.alarmSnoozed$messageChannelSuffix', pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
+      if (api == null) {
+        pigeonVar_channel.setMessageHandler(null);
+      } else {
+        pigeonVar_channel.setMessageHandler((Object? message) async {
+          assert(message != null,
+          'Argument for dev.flutter.pigeon.alarm.AlarmTriggerApi.alarmSnoozed was null.');
+          final List<Object?> args = (message as List<Object?>?)!;
+          final int? arg_alarmId = (args[0] as int?);
+          assert(arg_alarmId != null,
+              'Argument for dev.flutter.pigeon.alarm.AlarmTriggerApi.alarmSnoozed was null, expected non-null int.');
+          final int? arg_millisecondsSinceEpoch = (args[1] as int?);
+          assert(arg_millisecondsSinceEpoch != null,
+              'Argument for dev.flutter.pigeon.alarm.AlarmTriggerApi.alarmSnoozed was null, expected non-null int.');
+          try {
+            await api.alarmSnoozed(arg_alarmId!, arg_millisecondsSinceEpoch!);
+            return wrapResponse(empty: true);
+          } on PlatformException catch (e) {
+            return wrapResponse(error: e);
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }

--- a/pigeons/alarm_api.dart
+++ b/pigeons/alarm_api.dart
@@ -31,6 +31,7 @@ class AlarmSettingsWire {
     required this.iOSBackgroundAudio,
     required this.androidStopAlarmOnTermination,
     required this.preferConnectedAudioDevice,
+    required this.androidSnoozeDurationSeconds,
   });
 
   final int id;
@@ -47,6 +48,11 @@ class AlarmSettingsWire {
   final bool iOSBackgroundAudio;
   final bool androidStopAlarmOnTermination;
   final bool preferConnectedAudioDevice;
+
+  /// How long the snooze action defers the alarm, in seconds.
+  ///
+  /// Null, or anything below one, offers no snooze. Android only.
+  final int? androidSnoozeDurationSeconds;
 }
 
 class VolumeSettingsWire {
@@ -86,6 +92,7 @@ class NotificationSettingsWire {
     required this.iconColorGreen,
     required this.iconColorBlue,
     required this.keepNotificationAfterAlarmEnds,
+    required this.snoozeButton,
   });
 
   final String title;
@@ -97,6 +104,13 @@ class NotificationSettingsWire {
   final double? iconColorGreen;
   final double? iconColorBlue;
   final bool keepNotificationAfterAlarmEnds;
+
+  /// Label for the snooze action. Null omits the action.
+  ///
+  /// Only shown when [AlarmSettingsWire.androidSnoozeDurationSeconds] also
+  /// gives it a duration; a label alone describes nothing the platform can
+  /// perform. Android only.
+  final String? snoozeButton;
 }
 
 /// Errors that can occur when interacting with the Alarm API.
@@ -138,6 +152,28 @@ abstract class AlarmApi {
   });
 
   void disableWarningNotificationOnKill();
+
+  /// Drains the snoozes taken on the host side that no Dart isolate has
+  /// observed yet.
+  ///
+  /// A snooze is normally taken with no engine running: the notification and
+  /// the ringing screen are native, and a full screen intent starts the
+  /// process without starting Flutter. [AlarmTriggerApi.alarmSnoozed] reaches
+  /// nobody in that case, so the deferral is held until an isolate collects
+  /// it. Draining is destructive; a collected snooze is not reported twice.
+  @async
+  List<SnoozedAlarmWire> takeUnreportedSnoozes();
+}
+
+/// One deferral taken on the host side.
+class SnoozedAlarmWire {
+  const SnoozedAlarmWire({
+    required this.alarmId,
+    required this.millisecondsSinceEpoch,
+  });
+
+  final int alarmId;
+  final int millisecondsSinceEpoch;
 }
 
 @FlutterApi()
@@ -147,4 +183,13 @@ abstract class AlarmTriggerApi {
 
   @async
   void alarmStopped(int alarmId);
+
+  /// An alarm was deferred on the host side and re-registered for
+  /// [millisecondsSinceEpoch].
+  ///
+  /// Distinct from [alarmStopped] because the alarm is still owed: reporting a
+  /// snooze as a stop would tell the application the user dismissed something
+  /// they asked to be reminded of again.
+  @async
+  void alarmSnoozed(int alarmId, int millisecondsSinceEpoch);
 }

--- a/pigeons/alarm_api.dart
+++ b/pigeons/alarm_api.dart
@@ -31,7 +31,7 @@ class AlarmSettingsWire {
     required this.iOSBackgroundAudio,
     required this.androidStopAlarmOnTermination,
     required this.preferConnectedAudioDevice,
-    required this.androidSnoozeDurationSeconds,
+    required this.androidSnoozeDurationMillis,
   });
 
   final int id;
@@ -49,10 +49,13 @@ class AlarmSettingsWire {
   final bool androidStopAlarmOnTermination;
   final bool preferConnectedAudioDevice;
 
-  /// How long the snooze action defers the alarm, in seconds.
+  /// How long the snooze action defers the alarm, in milliseconds.
   ///
-  /// Null, or anything below one, offers no snooze. Android only.
-  final int? androidSnoozeDurationSeconds;
+  /// Null, or anything below one minute, offers no snooze. The floor exists
+  /// because Android scheduling falls back to a plain `Handler.postDelayed`
+  /// below a few seconds, which survives neither process death nor
+  /// cancellation. Android only.
+  final int? androidSnoozeDurationMillis;
 }
 
 class VolumeSettingsWire {
@@ -107,9 +110,9 @@ class NotificationSettingsWire {
 
   /// Label for the snooze action. Null omits the action.
   ///
-  /// Only shown when [AlarmSettingsWire.androidSnoozeDurationSeconds] also
-  /// gives it a duration; a label alone describes nothing the platform can
-  /// perform. Android only.
+  /// Only shown when [AlarmSettingsWire.androidSnoozeDurationMillis] also
+  /// gives it a usable duration; a label alone describes nothing the platform
+  /// can perform. Android only.
   final String? snoozeButton;
 }
 
@@ -153,21 +156,35 @@ abstract class AlarmApi {
 
   void disableWarningNotificationOnKill();
 
-  /// Drains the snoozes taken on the host side that no Dart isolate has
-  /// observed yet.
+  /// Lists snoozes the host has recorded but Dart has not yet applied.
   ///
-  /// A snooze is normally taken with no engine running: the notification and
-  /// the ringing screen are native, and a full screen intent starts the
-  /// process without starting Flutter. [AlarmTriggerApi.alarmSnoozed] reaches
-  /// nobody in that case, so the deferral is held until an isolate collects
-  /// it. Draining is destructive; a collected snooze is not reported twice.
+  /// A snooze is normally taken with no engine running: the notification is
+  /// native and a full screen intent starts the process without starting
+  /// Flutter, so [AlarmTriggerApi.alarmSnoozed] reaches nobody. The host holds
+  /// a marker until Dart has durably applied it.
+  ///
+  /// Reading is **not** destructive — the marker survives until
+  /// [acknowledgeSnooze] confirms Dart wrote the new time. A read that is
+  /// followed by a crash therefore loses nothing.
   @async
-  List<SnoozedAlarmWire> takeUnreportedSnoozes();
+  List<PendingSnoozeWire> getPendingSnoozes();
+
+  /// Drops the marker for [alarmId], but only if it still records exactly
+  /// [nextRingAtMillis].
+  ///
+  /// Matching on the timestamp as well as the id means a late acknowledgement
+  /// for an earlier snooze cannot discard a newer one taken for the same
+  /// alarm in the meantime.
+  @async
+  void acknowledgeSnooze({
+    required int alarmId,
+    required int nextRingAtMillis,
+  });
 }
 
-/// One deferral taken on the host side.
-class SnoozedAlarmWire {
-  const SnoozedAlarmWire({
+/// A snooze the host recorded and Dart has not yet applied.
+class PendingSnoozeWire {
+  const PendingSnoozeWire({
     required this.alarmId,
     required this.millisecondsSinceEpoch,
   });

--- a/pigeons/alarm_api.dart
+++ b/pigeons/alarm_api.dart
@@ -95,7 +95,7 @@ class NotificationSettingsWire {
     required this.iconColorGreen,
     required this.iconColorBlue,
     required this.keepNotificationAfterAlarmEnds,
-    required this.snoozeButton,
+    required this.androidSnoozeButton,
   });
 
   final String title;
@@ -113,7 +113,7 @@ class NotificationSettingsWire {
   /// Only shown when [AlarmSettingsWire.androidSnoozeDurationMillis] also
   /// gives it a usable duration; a label alone describes nothing the platform
   /// can perform. Android only.
-  final String? snoozeButton;
+  final String? androidSnoozeButton;
 }
 
 /// Errors that can occur when interacting with the Alarm API.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: alarm
 description: A simple Flutter alarm manager plugin for both iOS and Android.
-version: 5.6.0
+version: 5.7.0
 homepage: https://github.com/gdelataillade/alarm
 
 environment:

--- a/test/alarm_settings_test.dart
+++ b/test/alarm_settings_test.dart
@@ -7,6 +7,8 @@ void main() {
     DateTime? dateTime,
     String? assetAudioPath = 'assets/alarm.mp3',
     String? payload,
+    Duration? snoozeDuration,
+    String? snoozeButton,
   }) {
     return AlarmSettings(
       id: id,
@@ -16,12 +18,14 @@ void main() {
         volume: 0.8,
         fadeDuration: const Duration(seconds: 5),
       ),
-      notificationSettings: const NotificationSettings(
+      notificationSettings: NotificationSettings(
         title: 'Title',
         body: 'Body',
         stopButton: 'Stop',
+        androidSnoozeButton: snoozeButton,
       ),
       payload: payload,
+      androidSnoozeDuration: snoozeDuration,
     );
   }
 
@@ -142,6 +146,25 @@ void main() {
       );
       expect(wire.notificationSettings.title, 'Title');
     });
+
+    test('sends the snooze duration in milliseconds', () {
+      final settings = buildSettings(
+        snoozeDuration: const Duration(minutes: 9),
+        snoozeButton: 'Snooze',
+      );
+
+      final wire = settings.toWire();
+
+      expect(wire.androidSnoozeDurationMillis, 9 * 60 * 1000);
+      expect(wire.notificationSettings.androidSnoozeButton, 'Snooze');
+    });
+
+    test('leaves the snooze fields null when no snooze is configured', () {
+      final wire = buildSettings().toWire();
+
+      expect(wire.androidSnoozeDurationMillis, isNull);
+      expect(wire.notificationSettings.androidSnoozeButton, isNull);
+    });
   });
 
   group('AlarmSettings copyWith', () {
@@ -162,6 +185,35 @@ void main() {
       expect(settings.copyWith().payload, 'original');
       expect(settings.copyWith(payload: () => 'new').payload, 'new');
       expect(settings.copyWith(payload: () => null).payload, isNull);
+    });
+  });
+
+  group('AlarmSettings snooze JSON', () {
+    test('round trips the snooze duration and label', () {
+      final settings = buildSettings(
+        snoozeDuration: const Duration(minutes: 9),
+        snoozeButton: 'Snooze',
+      );
+
+      final restored = AlarmSettings.fromJson(settings.toJson());
+
+      expect(restored.androidSnoozeDuration, const Duration(minutes: 9));
+      expect(
+        restored.notificationSettings.androidSnoozeButton,
+        'Snooze',
+      );
+      expect(restored, equals(settings));
+    });
+
+    test('parses alarms stored before snooze existed', () {
+      final json = buildSettings().toJson()..remove('androidSnoozeDuration');
+      (json['notificationSettings']! as Map<String, dynamic>)
+          .remove('androidSnoozeButton');
+
+      final restored = AlarmSettings.fromJson(json);
+
+      expect(restored.androidSnoozeDuration, isNull);
+      expect(restored.notificationSettings.androidSnoozeButton, isNull);
     });
   });
 

--- a/test/alarm_settings_test.dart
+++ b/test/alarm_settings_test.dart
@@ -186,6 +186,33 @@ void main() {
       expect(settings.copyWith(payload: () => 'new').payload, 'new');
       expect(settings.copyWith(payload: () => null).payload, isNull);
     });
+
+    test('androidSnoozeDuration can be set and cleared through the callback',
+        () {
+      final settings = buildSettings(
+        snoozeDuration: const Duration(minutes: 9),
+        snoozeButton: 'Snooze',
+      );
+
+      expect(
+        settings.copyWith().androidSnoozeDuration,
+        const Duration(minutes: 9),
+      );
+      expect(
+        settings
+            .copyWith(
+              androidSnoozeDuration: () => const Duration(minutes: 5),
+            )
+            .androidSnoozeDuration,
+        const Duration(minutes: 5),
+      );
+      expect(
+        settings
+            .copyWith(androidSnoozeDuration: () => null)
+            .androidSnoozeDuration,
+        isNull,
+      );
+    });
   });
 
   group('AlarmSettings snooze JSON', () {

--- a/test/alarm_snooze_test.dart
+++ b/test/alarm_snooze_test.dart
@@ -227,6 +227,29 @@ void main() {
       expect(Alarm.scheduled.value.containsId(11), isFalse);
     });
 
+    test('rebuilds state for a marker that was already applied', () async {
+      // The crash window: Dart persisted the shifted time, then the process
+      // died before native could acknowledge. The marker survives and storage
+      // already agrees with it, so there is nothing to write — but a fresh
+      // isolate still has to surface the alarm.
+      final nextRingAt = DateTime.now().add(const Duration(minutes: 7));
+      await AlarmStorage.saveAlarm(buildAlarm(99, nextRingAt));
+      host.pending.add(
+        PendingSnoozeWire(
+          alarmId: 99,
+          millisecondsSinceEpoch: nextRingAt.millisecondsSinceEpoch,
+        ),
+      );
+
+      await Alarm.init();
+
+      expect(
+        Alarm.scheduled.value.containsId(99),
+        isTrue,
+        reason: 'an already-applied marker must not leave the alarm invisible',
+      );
+    });
+
     test('an alarm genuinely missed is still stopped', () async {
       // Guards the B1 fix against over-correcting: with no marker, a past
       // alarm that is not ringing should still be cleaned up.

--- a/test/alarm_snooze_test.dart
+++ b/test/alarm_snooze_test.dart
@@ -1,0 +1,333 @@
+import 'package:alarm/alarm.dart';
+import 'package:alarm/service/alarm_storage.dart';
+import 'package:alarm/src/alarm_trigger_api_impl.dart';
+import 'package:alarm/src/generated/platform_bindings.g.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Stands in for the Android host over the real pigeon channels.
+///
+/// The snooze contract is a negotiation between Dart and the host — the host
+/// records a marker, Dart applies it, the host drops it once Dart confirms —
+/// so the interesting behaviour only shows up when both halves are present.
+/// Recording every call lets a test assert what Dart did *not* do, which is
+/// what the B1 regression is about.
+class _FakeHost {
+  _FakeHost();
+
+  final List<String> calls = <String>[];
+  final List<PendingSnoozeWire> pending = <PendingSnoozeWire>[];
+  final List<(int, int)> acknowledged = <(int, int)>[];
+  final Set<int> ringing = <int>{};
+
+  static const _prefix = 'dev.flutter.pigeon.alarm.AlarmApi.';
+
+  void install() {
+    _handle('getPendingSnoozes', (_) => <Object?>[pending.toList()]);
+    _handle('acknowledgeSnooze', (args) {
+      acknowledged.add((args![0]! as int, args[1]! as int));
+      return <Object?>[null];
+    });
+    _handle('setAlarm', (_) => <Object?>[null]);
+    _handle('stopAlarm', (_) => <Object?>[null]);
+    _handle('stopAll', (_) => <Object?>[null]);
+    _handle('isRinging', (args) {
+      final id = args?[0] as int?;
+      final result = id == null ? ringing.isNotEmpty : ringing.contains(id);
+      return <Object?>[result];
+    });
+    _handle('setWarningNotificationOnKill', (_) => <Object?>[null]);
+    _handle('disableWarningNotificationOnKill', (_) => <Object?>[null]);
+  }
+
+  void _handle(String name, Object? Function(List<Object?>? args) respond) {
+    final channel = BasicMessageChannel<Object?>(
+      '$_prefix$name',
+      AlarmApi.pigeonChannelCodec,
+    );
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockDecodedMessageHandler<Object?>(channel, (message) async {
+      calls.add(name);
+      return respond(message as List<Object?>?);
+    });
+  }
+
+  void remove() {
+    for (final name in const [
+      'getPendingSnoozes',
+      'acknowledgeSnooze',
+      'setAlarm',
+      'stopAlarm',
+      'stopAll',
+      'isRinging',
+      'setWarningNotificationOnKill',
+      'disableWarningNotificationOnKill',
+    ]) {
+      final channel = BasicMessageChannel<Object?>(
+        '$_prefix$name',
+        AlarmApi.pigeonChannelCodec,
+      );
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockDecodedMessageHandler<Object?>(channel, null);
+    }
+  }
+}
+
+/// Lets already-queued microtasks run.
+///
+/// `Alarm.snoozed` is a broadcast stream, so a listener is notified in a
+/// microtask rather than synchronously with the `add`.
+Future<void> pump() => Future<void>.delayed(Duration.zero);
+
+/// Delivers an `alarmSnoozed` call the way the host would, and completes only
+/// when Dart has finished handling it.
+Future<void> hostReportsSnooze(int alarmId, DateTime nextRingAt) async {
+  const channelName = 'dev.flutter.pigeon.alarm.AlarmTriggerApi.alarmSnoozed';
+  final encoded = AlarmTriggerApi.pigeonChannelCodec.encodeMessage(
+    <Object?>[alarmId, nextRingAt.millisecondsSinceEpoch],
+  );
+  await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .handlePlatformMessage(channelName, encoded, (_) {});
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late _FakeHost host;
+
+  AlarmSettings buildAlarm(
+    int id,
+    DateTime dateTime, {
+    Duration? snoozeDuration = const Duration(minutes: 9),
+  }) {
+    return AlarmSettings(
+      id: id,
+      dateTime: dateTime,
+      volumeSettings: const VolumeSettings.fixed(),
+      androidSnoozeDuration: snoozeDuration,
+      notificationSettings: const NotificationSettings(
+        title: 'Wake up',
+        body: '',
+        androidSnoozeButton: 'Snooze',
+      ),
+    );
+  }
+
+  setUp(() {
+    debugDefaultTargetPlatformOverride = TargetPlatform.android;
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    Alarm.resetForTesting();
+    AlarmStorage.resetForTesting();
+    AlarmTriggerApiImpl.resetForTesting();
+    host = _FakeHost()..install();
+  });
+
+  tearDown(() {
+    host.remove();
+    Alarm.resetForTesting();
+    AlarmStorage.resetForTesting();
+    AlarmTriggerApiImpl.resetForTesting();
+    debugDefaultTargetPlatformOverride = null;
+  });
+
+  group('snooze reconciliation on init', () {
+    test(
+      'B1: reopening before the snooze fires does not cancel it',
+      () async {
+        // The alarm rang at its original time and the user snoozed from the
+        // notification with no engine running, so Dart still has the original
+        // past time. Reopening the app must not read that as a missed alarm.
+        final originalTime =
+            DateTime.now().subtract(const Duration(minutes: 2));
+        final nextRingAt = DateTime.now().add(const Duration(minutes: 7));
+        await AlarmStorage.saveAlarm(buildAlarm(42, originalTime));
+        host.pending.add(
+          PendingSnoozeWire(
+            alarmId: 42,
+            millisecondsSinceEpoch: nextRingAt.millisecondsSinceEpoch,
+          ),
+        );
+
+        await Alarm.init();
+
+        expect(
+          host.calls,
+          isNot(contains('stopAlarm')),
+          reason: 'the snoozed alarm must not be stopped as if it were missed',
+        );
+
+        final stored = await Alarm.getAlarm(42);
+        expect(stored, isNotNull);
+        expect(
+          stored!.dateTime.millisecondsSinceEpoch,
+          nextRingAt.millisecondsSinceEpoch,
+          reason: 'Dart storage must hold the shifted time, not the original',
+        );
+      },
+    );
+
+    test('B2: a marker recorded with no engine is applied on the next init',
+        () async {
+      final nextRingAt = DateTime.now().add(const Duration(minutes: 9));
+      await AlarmStorage.saveAlarm(
+        buildAlarm(7, DateTime.now().subtract(const Duration(minutes: 1))),
+      );
+      host.pending.add(
+        PendingSnoozeWire(
+          alarmId: 7,
+          millisecondsSinceEpoch: nextRingAt.millisecondsSinceEpoch,
+        ),
+      );
+
+      await Alarm.init();
+
+      expect(Alarm.scheduled.value.containsId(7), isTrue);
+      expect(Alarm.ringing.value.containsId(7), isFalse);
+    });
+
+    test('acknowledges the marker it applied, matching id and timestamp',
+        () async {
+      final nextRingAt = DateTime.now().add(const Duration(minutes: 5));
+      await AlarmStorage.saveAlarm(
+        buildAlarm(3, DateTime.now().subtract(const Duration(minutes: 1))),
+      );
+      host.pending.add(
+        PendingSnoozeWire(
+          alarmId: 3,
+          millisecondsSinceEpoch: nextRingAt.millisecondsSinceEpoch,
+        ),
+      );
+
+      await Alarm.init();
+
+      expect(
+        host.acknowledged,
+        contains((3, nextRingAt.millisecondsSinceEpoch)),
+      );
+    });
+
+    test('a marker whose time has already passed is refused, not applied',
+        () async {
+      // Applying it would rewrite the alarm to a past time, which the
+      // reconciliation loop then deletes.
+      final original = DateTime.now().subtract(const Duration(minutes: 30));
+      final stalePending = DateTime.now().subtract(const Duration(minutes: 10));
+      await AlarmStorage.saveAlarm(buildAlarm(11, original));
+      host.pending.add(
+        PendingSnoozeWire(
+          alarmId: 11,
+          millisecondsSinceEpoch: stalePending.millisecondsSinceEpoch,
+        ),
+      );
+
+      await Alarm.init();
+
+      expect(Alarm.scheduled.value.containsId(11), isFalse);
+    });
+
+    test('an alarm genuinely missed is still stopped', () async {
+      // Guards the B1 fix against over-correcting: with no marker, a past
+      // alarm that is not ringing should still be cleaned up.
+      await AlarmStorage.saveAlarm(
+        buildAlarm(5, DateTime.now().subtract(const Duration(hours: 1))),
+      );
+
+      await Alarm.init();
+
+      expect(host.calls, contains('stopAlarm'));
+    });
+  });
+
+  group('live snooze report', () {
+    test('moves the alarm forward and emits on Alarm.snoozed', () async {
+      final nextRingAt = DateTime.now().add(const Duration(minutes: 9));
+      await AlarmStorage.saveAlarm(
+        buildAlarm(21, DateTime.now().add(const Duration(minutes: 1))),
+      );
+      await Alarm.init();
+
+      final events = <({int id, DateTime nextRingAt})>[];
+      final sub = Alarm.snoozed.listen(events.add);
+      addTearDown(sub.cancel);
+
+      await hostReportsSnooze(21, nextRingAt);
+      await pump();
+
+      expect(events, hasLength(1));
+      expect(events.single.id, 21);
+      final stored = await Alarm.getAlarm(21);
+      expect(
+        stored!.dateTime.millisecondsSinceEpoch,
+        nextRingAt.millisecondsSinceEpoch,
+      );
+    });
+
+    test('applying the same deferral twice changes nothing', () async {
+      final nextRingAt = DateTime.now().add(const Duration(minutes: 9));
+      await AlarmStorage.saveAlarm(
+        buildAlarm(22, DateTime.now().add(const Duration(minutes: 1))),
+      );
+      await Alarm.init();
+
+      final events = <({int id, DateTime nextRingAt})>[];
+      final sub = Alarm.snoozed.listen(events.add);
+      addTearDown(sub.cancel);
+
+      await hostReportsSnooze(22, nextRingAt);
+      await pump();
+      await hostReportsSnooze(22, nextRingAt);
+      await pump();
+
+      expect(
+        events,
+        hasLength(1),
+        reason: 'a replayed marker must collapse into the live report',
+      );
+      final stored = await Alarm.getAlarm(22);
+      expect(
+        stored!.dateTime.millisecondsSinceEpoch,
+        nextRingAt.millisecondsSinceEpoch,
+      );
+    });
+
+    test('an older deferral cannot pull a newer one backwards', () async {
+      final earlier = DateTime.now().add(const Duration(minutes: 5));
+      final later = DateTime.now().add(const Duration(minutes: 15));
+      await AlarmStorage.saveAlarm(
+        buildAlarm(23, DateTime.now().add(const Duration(minutes: 1))),
+      );
+      await Alarm.init();
+
+      await hostReportsSnooze(23, later);
+      await hostReportsSnooze(23, earlier);
+
+      final stored = await Alarm.getAlarm(23);
+      expect(
+        stored!.dateTime.millisecondsSinceEpoch,
+        later.millisecondsSinceEpoch,
+      );
+    });
+
+    test('the reply to the host waits for Dart to persist', () async {
+      // The host drops its marker on the strength of this reply, so replying
+      // before the write lands would lose the deferral to a crash in between.
+      final nextRingAt = DateTime.now().add(const Duration(minutes: 9));
+      await AlarmStorage.saveAlarm(
+        buildAlarm(31, DateTime.now().add(const Duration(minutes: 1))),
+      );
+      await Alarm.init();
+
+      await hostReportsSnooze(31, nextRingAt);
+
+      // handlePlatformMessage completes only once the handler's future does,
+      // so by here the write must already be visible.
+      final stored = await Alarm.getAlarm(31);
+      expect(
+        stored!.dateTime.millisecondsSinceEpoch,
+        nextRingAt.millisecondsSinceEpoch,
+      );
+    });
+  });
+}

--- a/test/alarm_validation_test.dart
+++ b/test/alarm_validation_test.dart
@@ -4,14 +4,20 @@ import 'package:alarm/utils/alarm_exception.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  AlarmSettings buildSettings(int id) {
+  AlarmSettings buildSettings(
+    int id, {
+    Duration? snoozeDuration,
+    String? snoozeButton,
+  }) {
     return AlarmSettings(
       id: id,
       dateTime: DateTime(2030),
       volumeSettings: const VolumeSettings.fixed(),
-      notificationSettings: const NotificationSettings(
+      androidSnoozeDuration: snoozeDuration,
+      notificationSettings: NotificationSettings(
         title: 'Title',
         body: 'Body',
+        androidSnoozeButton: snoozeButton,
       ),
     );
   }
@@ -53,6 +59,64 @@ void main() {
       expect(
         () => Alarm.alarmSettingsValidation(buildSettings(-2147483649)),
         throwsA(isA<AlarmException>()),
+      );
+    });
+
+    test('rejects a non-positive snooze duration', () {
+      expect(
+        () => Alarm.alarmSettingsValidation(
+          buildSettings(42, snoozeDuration: Duration.zero),
+        ),
+        throwsA(isA<AlarmException>()),
+      );
+      expect(
+        () => Alarm.alarmSettingsValidation(
+          buildSettings(42, snoozeDuration: const Duration(seconds: -1)),
+        ),
+        throwsA(isA<AlarmException>()),
+      );
+    });
+
+    test('accepts a snooze duration at the minimum', () {
+      expect(
+        () => Alarm.alarmSettingsValidation(
+          buildSettings(
+            42,
+            snoozeDuration: AlarmSettings.minSnoozeDuration,
+            snoozeButton: 'Snooze',
+          ),
+        ),
+        returnsNormally,
+      );
+    });
+
+    test('only warns for a snooze below the minimum', () {
+      // Inert on iOS and gated natively, so a too-short duration degrades to
+      // no snooze rather than failing the whole alarm.
+      expect(
+        () => Alarm.alarmSettingsValidation(
+          buildSettings(
+            42,
+            snoozeDuration: const Duration(seconds: 5),
+            snoozeButton: 'Snooze',
+          ),
+        ),
+        returnsNormally,
+      );
+    });
+
+    test('only warns when the label and duration do not agree', () {
+      expect(
+        () => Alarm.alarmSettingsValidation(
+          buildSettings(42, snoozeButton: 'Snooze'),
+        ),
+        returnsNormally,
+      );
+      expect(
+        () => Alarm.alarmSettingsValidation(
+          buildSettings(42, snoozeDuration: const Duration(minutes: 9)),
+        ),
+        returnsNormally,
       );
     });
   });

--- a/test/notification_settings_test.dart
+++ b/test/notification_settings_test.dart
@@ -10,6 +10,7 @@ void main() {
         title: 'Title',
         body: 'Body',
         stopButton: 'Stop',
+        androidSnoozeButton: 'Snooze',
         icon: 'notification_icon',
         iconColor: Color(0xFF862778),
         keepNotificationAfterAlarmEnds: true,
@@ -18,6 +19,27 @@ void main() {
       final restored = NotificationSettings.fromJson(settings.toJson());
 
       expect(restored, equals(settings));
+    });
+
+    test('encodes iconColor as its ARGB integer', () {
+      // Pinned because the JSON is persisted: alarms saved by earlier versions
+      // must keep parsing after iconColor moved to a JsonConverter.
+      const settings = NotificationSettings(
+        title: 'Title',
+        body: 'Body',
+        iconColor: Color(0xFF862778),
+      );
+
+      expect(settings.toJson()['iconColor'], 0xFF862778);
+      expect(
+        NotificationSettings.fromJson(const <String, dynamic>{
+          'title': 'Title',
+          'body': 'Body',
+          'iconColor': 0xFF862778,
+          'keepNotificationAfterAlarmEnds': false,
+        }).iconColor,
+        const Color(0xFF862778),
+      );
     });
 
     test('round trips with optional fields absent', () {

--- a/test/notification_settings_test.dart
+++ b/test/notification_settings_test.dart
@@ -84,6 +84,28 @@ void main() {
     });
   });
 
+  group('NotificationSettings snooze copyWith', () {
+    test('androidSnoozeButton can be set and cleared through the callback', () {
+      const settings = NotificationSettings(
+        title: 'Title',
+        body: 'Body',
+        androidSnoozeButton: 'Snooze',
+      );
+
+      expect(settings.copyWith().androidSnoozeButton, 'Snooze');
+      expect(
+        settings
+            .copyWith(androidSnoozeButton: () => 'Later')
+            .androidSnoozeButton,
+        'Later',
+      );
+      expect(
+        settings.copyWith(androidSnoozeButton: () => null).androidSnoozeButton,
+        isNull,
+      );
+    });
+  });
+
   group('NotificationSettings copyWith', () {
     test('replaces only the provided fields', () {
       const settings = NotificationSettings(


### PR DESCRIPTION
### Problem

The notification carries a stop action and nothing else, so an alarm can only be deferred from inside the app — which defeats the point of a snooze, since the user has to unlock the device and navigate to it.

In #211 you wrote that action buttons were on your to-do list, and that the hard parts were doing it native-side where the notifications are managed, and updating local storage. That is what this does.

### Change

An alarm given `androidSnoozeDuration`, and a notification given a `snoozeButton` label, offers a snooze that stops the current ring and re-registers the alarm that far ahead through the ordinary scheduling path.

```dart
AlarmSettings(
  // ...
  androidSnoozeDuration: const Duration(minutes: 5),
  notificationSettings: const NotificationSettings(
    title: 'Wake up',
    body: '',
    stopButton: 'Stop',
    snoozeButton: 'Snooze',
  ),
);
```

Both are required: a label without a duration describes an action the platform cannot perform.

### Reported as a deferral, not a stop

A snooze produces `alarmSnoozed`, never `alarmStopped`. A snoozed alarm is still owed, and reporting it as a stop would tell the app the user dismissed something they asked to be reminded of again.

```dart
Alarm.snoozed.listen((snooze) {
  print('Alarm ${snooze.id} rings again at ${snooze.nextRingAt}');
});
```

### Why it is also stored

The button is normally pressed with **no Flutter engine running** — the notification is native and the process may not be up — so `alarmSnoozed` reaches nobody. Each deferral is therefore recorded in `AlarmStorage` and drained on the next `Alarm.init()` through `takeUnreportedSnoozes`.

Without that, an app tracking its own alarm state finds an alarm whose instant moved with nothing explaining why, and a reconciliation pass would move it back — silently undoing the snooze.

Receiving both the live report and the drained record applies the same deferral twice, which changes nothing.

### Compatibility

Alarms with no snooze duration behave exactly as before. The new `AlarmApi.takeUnreportedSnoozes` returns an empty list on iOS, where snoozing does not apply.

### A note on the generated files

`lib/model/*.g.dart` are edited by hand: `build_runner` on my toolchain emits null-aware elements your `sdk: ">=3.0.0 <4.0.0"` lower bound rejects, and fails on `Color? iconColor`. Please regenerate them with yours rather than taking mine. The pigeon outputs **are** properly regenerated from `pigeons/alarm_api.dart`.

### Testing

Example app builds and runs on Android; `flutter analyze` clean under your `very_good_analysis` config. Exercised in a real application on a Samsung SM-S928B (Android 16), including the no-engine path: snooze from the lock screen, kill the app, reopen, and the deferral is replayed.
