### PR TITLE
fix(android): stop silently losing alarms (#419, #420)

### DIFF
--- a/android/src/main/kotlin/com/gdelataillade/alarm/alarm/BootReceiver.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/alarm/BootReceiver.kt
@@ -33,8 +33,22 @@ class BootReceiver : BroadcastReceiver() {
 
                 // Call the setAlarm method in AlarmPlugin with the custom context
                 val alarmApi = AlarmApiImpl(context)
-                alarmApi.setAlarm(alarm)
-                Log.d(TAG, "Alarm rescheduled successfully for ID: ${alarm.id}")
+                if (alarmApi.setAlarm(alarm)) {
+                    Log.d(TAG, "Alarm rescheduled successfully for ID: ${alarm.id}")
+                } else {
+                    // Deliberately left in storage, unlike the Pigeon set path which
+                    // unsaves so Dart never reports an alarm the platform never armed.
+                    // Here that record is the only thing a later attempt could re-arm
+                    // from, and there is no engine running to be told about the
+                    // failure — dropping it would silently lose the user's alarm for
+                    // good. A boot-time failure is often transient anyway, because the
+                    // system is still coming up.
+                    Log.e(
+                        TAG,
+                        "Failed to re-arm alarm ${alarm.id} after reboot. It stays stored " +
+                            "so a later Alarm.init() or reboot can retry."
+                    )
+                }
             } catch (e: Exception) {
                 Log.e(TAG, "Exception while rescheduling alarm: $alarm", e)
             }

--- a/android/src/main/kotlin/com/gdelataillade/alarm/api/AlarmApiImpl.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/api/AlarmApiImpl.kt
@@ -1,7 +1,9 @@
 package com.gdelataillade.alarm.api
 
 import com.gdelataillade.alarm.generated.AlarmApi
+import com.gdelataillade.alarm.generated.AlarmErrorCode
 import com.gdelataillade.alarm.generated.AlarmSettingsWire
+import com.gdelataillade.alarm.generated.FlutterError
 import com.gdelataillade.alarm.generated.PendingSnoozeWire
 import android.app.AlarmManager
 import android.app.PendingIntent
@@ -25,8 +27,47 @@ class AlarmApiImpl(private val context: Context) : AlarmApi {
     private val alarmIds: MutableList<Int> = mutableListOf()
 
     override fun setAlarm(alarmSettings: AlarmSettingsWire, callback: (Result<Unit>) -> Unit) {
-        setAlarm(AlarmSettings.fromWire(alarmSettings))
-        callback(Result.success(Unit))
+        val alarm = AlarmSettings.fromWire(alarmSettings)
+        if (setAlarm(alarm)) {
+            callback(Result.success(Unit))
+            return
+        }
+
+        // AlarmScheduler saves before it arms, so a failure leaves a stored alarm the
+        // platform never armed. Reporting that as success is what made the failure
+        // unobservable: Alarm.set() returned true, getAlarms() kept listing the alarm,
+        // and nothing rang.
+        //
+        // Dart's own failure path stops the alarm moments after this reply, which is
+        // what really cleans up, but the process can die in between — and a phantom
+        // that survives in storage is re-armed by BootReceiver after the next reboot,
+        // ringing an alarm the app believes does not exist. So undo the halves that
+        // landed here too.
+        //
+        // Each step is isolated on purpose. This is the failure path, so one cleanup
+        // throwing must not take the others down with it, and the reply has to be
+        // reached whatever happens or Dart waits on a channel error instead of the
+        // real cause.
+        alarmIds.remove(alarm.id)
+        runCatching { cancelPendingBroadcast(alarm.id) }
+            .onFailure { Log.e(TAG, "Failed to cancel the pending broadcast for ${alarm.id}", it) }
+        runCatching { AlarmStorage(context).unsaveAlarm(alarm.id) }
+            .onFailure { Log.e(TAG, "Failed to unsave ${alarm.id} after a failed arm", it) }
+        runCatching { WarningNotificationState.refresh(context) }
+            .onFailure { Log.e(TAG, "Failed to refresh the kill-warning state", it) }
+
+        callback(
+            Result.failure(
+                FlutterError(
+                    // The raw int, not the name: Dart maps the code back with
+                    // int.tryParse, so a name would arrive as AlarmErrorCode.unknown.
+                    AlarmErrorCode.PLUGIN_INTERNAL.raw.toString(),
+                    "Alarm ${alarm.id} could not be armed. " +
+                        "See the AlarmScheduler logs for the cause.",
+                    null
+                )
+            )
+        )
     }
 
     override fun stopAlarm(alarmId: Long, callback: (Result<Unit>) -> Unit) {
@@ -38,18 +79,8 @@ class AlarmApiImpl(private val context: Context) : AlarmApi {
         val serviceIsRunning = AlarmService.instance != null
         AlarmService.instance?.handleStopAlarmCommand(id)
 
-        // Intent to cancel the future alarm if it's set
-        val alarmIntent = Intent(context, AlarmReceiver::class.java)
-        val pendingIntent = PendingIntent.getBroadcast(
-            context,
-            id,
-            alarmIntent,
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-        )
-
-        // Cancel the future alarm using AlarmManager
-        val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
-        alarmManager.cancel(pendingIntent)
+        // Cancel the future alarm if it's set
+        cancelPendingBroadcast(id)
 
         alarmIds.remove(id)
         AlarmStorage(context).unsaveAlarm(id)
@@ -127,7 +158,17 @@ class AlarmApiImpl(private val context: Context) : AlarmApi {
         callback(Result.success(Unit))
     }
 
-    fun setAlarm(alarm: AlarmSettings) {
+    /**
+     * Arms [alarm] and records it as one of ours.
+     *
+     * Returns whether the alarm is now both stored and armed. Deliberately rolls back
+     * nothing of its own: what a failure *means* depends on the caller, which is the
+     * same reason [AlarmScheduler.schedule] leaves it alone. The Pigeon path above
+     * unsaves, because Dart is waiting for an answer and a stored-but-unarmed alarm
+     * would be reported as scheduled forever. BootReceiver must not, because native
+     * storage is the only record it re-arms from.
+     */
+    fun setAlarm(alarm: AlarmSettings): Boolean {
         if (alarmIds.contains(alarm.id)) {
             Log.w(TAG, "Stopping alarm with identical ID=${alarm.id} before scheduling a new one.")
             stopAlarm(alarm.id.toLong()) {}
@@ -138,7 +179,39 @@ class AlarmApiImpl(private val context: Context) : AlarmApi {
         // Persisting and arming live in AlarmScheduler so the snooze path can
         // reuse them without also inheriting the stop-and-replace preamble
         // above, which would report the deferral to Flutter as a stop.
-        AlarmScheduler.schedule(context, alarm)
+        return AlarmScheduler.schedule(context, alarm)
     }
 
+    /**
+     * Cancels any `AlarmManager` entry armed for [id].
+     *
+     * Rebuilding the same broadcast intent is how `AlarmManager` identifies the entry
+     * to drop: `PendingIntent` equality ignores extras, so the plain intent here
+     * matches whatever [AlarmScheduler] armed.
+     *
+     * Never throws. Both callers reach this while cleaning up — including the case
+     * where the alarm service itself is unavailable, which is one of the failures the
+     * rollback exists for — so a cancel that cannot happen must not take the rest of
+     * the cleanup, or the reply to Dart, down with it.
+     */
+    private fun cancelPendingBroadcast(id: Int) {
+        try {
+            val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as? AlarmManager
+            if (alarmManager == null) {
+                Log.e(TAG, "Cannot cancel alarm $id: AlarmManager is not available.")
+                return
+            }
+
+            val alarmIntent = Intent(context, AlarmReceiver::class.java)
+            val pendingIntent = PendingIntent.getBroadcast(
+                context,
+                id,
+                alarmIntent,
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+            )
+            alarmManager.cancel(pendingIntent)
+        } catch (e: Exception) {
+            Log.e(TAG, "Error while cancelling the pending broadcast for alarm $id", e)
+        }
+    }
 }

--- a/android/src/main/kotlin/com/gdelataillade/alarm/services/AlarmScheduler.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/services/AlarmScheduler.kt
@@ -111,15 +111,24 @@ object AlarmScheduler {
             )
 
             val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as? AlarmManager
-                ?: throw IllegalStateException("AlarmManager not available")
+            if (alarmManager == null) {
+                Log.e(TAG, "Cannot arm alarm $id: AlarmManager is not available.")
+                return false
+            }
 
             setExactAlarm(alarmManager, triggerTimeMillis, pendingIntent)
             true
-        } catch (e: ClassCastException) {
-            Log.e(TAG, "AlarmManager service type casting failed", e)
-            false
         } catch (e: IllegalStateException) {
-            Log.e(TAG, "AlarmManager service not available", e)
+            // Reporting this as "service not available" was misleading: a missing
+            // service is handled above, and what reaches here is AlarmManager
+            // refusing the alarm — documented for an app that already holds the
+            // maximum number of scheduled alarms (500).
+            Log.e(
+                TAG,
+                "AlarmManager refused to arm alarm $id. The likely cause is this " +
+                    "app having reached the per-app limit on scheduled alarms.",
+                e
+            )
             false
         } catch (e: Exception) {
             Log.e(TAG, "Error while arming alarm $id", e)

--- a/lib/alarm.dart
+++ b/lib/alarm.dart
@@ -94,6 +94,37 @@ class Alarm {
 
   static Future<void>? _checkAlarmFuture;
 
+  /// How long past its due time an alarm the platform does not report as
+  /// ringing is still left alone by [checkAlarm].
+  ///
+  /// An alarm due at 06:00:00.000 is not audible at 06:00:00.000. On Android
+  /// the broadcast has to be delivered, the process may have to start, the
+  /// foreground service has to come up and the player has to prepare, and the
+  /// alarm only counts as ringing at the end of all that — so a reconciliation
+  /// landing in that gap cannot tell "already fired and was stopped" from
+  /// "about to sound". Cancelling the second is by far the worse mistake: the
+  /// alarm never rings, and every signal the app has says it was set.
+  ///
+  /// Generous on purpose, because the two outcomes are not comparable. Sparing
+  /// an alarm that really did fail costs a stale entry in storage; stopping one
+  /// that was about to ring costs the user their morning.
+  ///
+  /// A spared alarm is not tidied up on a timer. [checkAlarm] runs only when it
+  /// is called — in practice from [init] — so an alarm that genuinely failed
+  /// can sit in storage until the next pass. That is an accepted risk rather
+  /// than a harmless one: the entry may be an inexact alarm still pending and
+  /// about to ring late, which is exactly what this window protects, and a
+  /// native record that survives a reboot is re-armed by `BootReceiver`.
+  /// Scheduling a follow-up reconciliation was considered and rejected — a
+  /// timer would not fire in a background isolate that gets torn down, and it
+  /// could stop an alarm at the moment the user is acting on it.
+  ///
+  /// Does not cover an alarm delayed past this window by the inexact fallback
+  /// `AlarmScheduler` uses when the exact alarm permission is revoked. Telling
+  /// "armed and still pending" from "never armed" needs durable native state,
+  /// which the platform does not expose today.
+  static const _ringStartGrace = Duration(seconds: 30);
+
   static Future<void> _checkAlarm() async {
     final snoozed = await _applyPendingSnoozes();
 
@@ -132,6 +163,22 @@ class Alarm {
                 'reconciling, so it is left scheduled.');
             continue;
           }
+
+          // Read from [current] like the branch above, so both agree on the
+          // authoritative time. Android only: iOS arrives here having already
+          // been through [stopAll], which leaves [current] null and nothing to
+          // spare, so the gate is really documenting whose delivery chain this
+          // is about.
+          if (android && current != null) {
+            final overdue = DateTime.now().difference(current.dateTime);
+            if (overdue < _ringStartGrace) {
+              _log.info('Alarm ${alarm.id} came due '
+                  '${overdue.inMilliseconds}ms ago and is not audible yet, so '
+                  'it is left alone rather than stopped.');
+              continue;
+            }
+          }
+
           await stop(alarm.id);
         }
       }

--- a/test/alarm_check_test.dart
+++ b/test/alarm_check_test.dart
@@ -1,0 +1,149 @@
+import 'package:alarm/alarm.dart';
+import 'package:alarm/service/alarm_storage.dart';
+import 'package:alarm/src/alarm_trigger_api_impl.dart';
+import 'package:alarm/src/generated/platform_bindings.g.dart';
+import 'package:alarm/utils/alarm_exception.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'support/fake_host.dart';
+
+/// Reconciliation and set-failure behaviour, both about the plugin not lying
+/// about an alarm's state.
+///
+/// The two regressions here are the worst shape a failure can take in an alarm
+/// app, because nothing reports them: an alarm that was about to ring being
+/// cancelled by a startup pass, and a host that could not arm an alarm being
+/// reported as success.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late FakeHost host;
+
+  AlarmSettings buildAlarm(int id, DateTime dateTime) => AlarmSettings(
+        id: id,
+        dateTime: dateTime,
+        volumeSettings: const VolumeSettings.fixed(),
+        notificationSettings: const NotificationSettings(
+          title: 'Wake up',
+          body: '',
+        ),
+      );
+
+  setUp(() {
+    debugDefaultTargetPlatformOverride = TargetPlatform.android;
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    Alarm.resetForTesting();
+    AlarmStorage.resetForTesting();
+    AlarmTriggerApiImpl.resetForTesting();
+    host = FakeHost()..install();
+  });
+
+  tearDown(() {
+    host.remove();
+    Alarm.resetForTesting();
+    AlarmStorage.resetForTesting();
+    AlarmTriggerApiImpl.resetForTesting();
+    debugDefaultTargetPlatformOverride = null;
+  });
+
+  group('checkAlarm ring-start grace', () {
+    test('an alarm that came due moments ago is left alone', () async {
+      // The alarm is due but the host does not report it as ringing yet, which
+      // is what the whole delivery chain looks like from Dart: broadcast, maybe
+      // a process start, foreground service, player prepare. Stopping here
+      // cancels a ring that is on its way.
+      await AlarmStorage.saveAlarm(
+        buildAlarm(42, DateTime.now().subtract(const Duration(seconds: 2))),
+      );
+
+      await Alarm.init();
+
+      expect(
+        host.calls,
+        isNot(contains('stopAlarm')),
+        reason: 'an alarm that is about to sound must not be cancelled',
+      );
+      expect(
+        await Alarm.getAlarm(42),
+        isNotNull,
+        reason: 'and it must stay stored so the ring can still be reported',
+      );
+    });
+
+    test('an alarm long past due is still stopped', () async {
+      await AlarmStorage.saveAlarm(
+        buildAlarm(42, DateTime.now().subtract(const Duration(minutes: 2))),
+      );
+
+      await Alarm.init();
+
+      expect(host.calls, contains('stopAlarm'));
+      expect(await Alarm.getAlarms(), isEmpty);
+    });
+
+    test('an alarm the host reports as ringing is marked ringing, not spared',
+        () async {
+      // Guards that the grace window did not shadow the branch above it: a host
+      // that says "ringing" must still put the alarm on the ringing stream.
+      final alarm =
+          buildAlarm(42, DateTime.now().subtract(const Duration(seconds: 2)));
+      await AlarmStorage.saveAlarm(alarm);
+      host.ringing.add(42);
+
+      await Alarm.init();
+
+      expect(Alarm.ringing.value.containsId(42), isTrue);
+      expect(host.calls, isNot(contains('stopAlarm')));
+    });
+
+    test('iOS still stops a past-due alarm', () async {
+      // Asserts preserved behaviour rather than isolating the Android gate:
+      // iOS runs stopAll() before the loop, which empties storage, so the
+      // re-read finds nothing and the grace window is unreachable either way.
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      await AlarmStorage.saveAlarm(
+        buildAlarm(42, DateTime.now().subtract(const Duration(seconds: 2))),
+      );
+
+      await Alarm.init();
+
+      expect(host.calls, contains('stopAll'));
+      expect(host.calls, contains('stopAlarm'));
+      expect(await Alarm.getAlarms(), isEmpty);
+    });
+  });
+
+  group('set() when the host cannot arm the alarm', () {
+    test('reports the failure and leaves nothing behind', () async {
+      // The host stores the alarm before arming it, so a failure it reported as
+      // success left a phantom: set() returned true, getAlarms() kept listing
+      // the alarm, and nothing ever rang.
+      host.setAlarmError = (
+        code: AlarmErrorCode.pluginInternal.index.toString(),
+        message: 'Alarm 42 could not be armed.',
+      );
+
+      await expectLater(
+        Alarm.set(
+          alarmSettings:
+              buildAlarm(42, DateTime.now().add(const Duration(hours: 1))),
+        ),
+        throwsA(
+          isA<AlarmException>()
+              .having((e) => e.code, 'code', AlarmErrorCode.pluginInternal),
+        ),
+      );
+
+      expect(host.calls, contains('setAlarm'));
+      expect(
+        host.calls,
+        contains('stopAlarm'),
+        reason: 'the failed alarm has to be torn down, not left half-created',
+      );
+      expect(await Alarm.getAlarms(), isEmpty);
+      expect(Alarm.scheduled.value.alarms, isEmpty);
+    });
+  });
+}

--- a/test/alarm_snooze_test.dart
+++ b/test/alarm_snooze_test.dart
@@ -3,77 +3,10 @@ import 'package:alarm/service/alarm_storage.dart';
 import 'package:alarm/src/alarm_trigger_api_impl.dart';
 import 'package:alarm/src/generated/platform_bindings.g.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-/// Stands in for the Android host over the real pigeon channels.
-///
-/// The snooze contract is a negotiation between Dart and the host — the host
-/// records a marker, Dart applies it, the host drops it once Dart confirms —
-/// so the interesting behaviour only shows up when both halves are present.
-/// Recording every call lets a test assert what Dart did *not* do, which is
-/// what the B1 regression is about.
-class _FakeHost {
-  _FakeHost();
-
-  final List<String> calls = <String>[];
-  final List<PendingSnoozeWire> pending = <PendingSnoozeWire>[];
-  final List<(int, int)> acknowledged = <(int, int)>[];
-  final Set<int> ringing = <int>{};
-
-  static const _prefix = 'dev.flutter.pigeon.alarm.AlarmApi.';
-
-  void install() {
-    _handle('getPendingSnoozes', (_) => <Object?>[pending.toList()]);
-    _handle('acknowledgeSnooze', (args) {
-      acknowledged.add((args![0]! as int, args[1]! as int));
-      return <Object?>[null];
-    });
-    _handle('setAlarm', (_) => <Object?>[null]);
-    _handle('stopAlarm', (_) => <Object?>[null]);
-    _handle('stopAll', (_) => <Object?>[null]);
-    _handle('isRinging', (args) {
-      final id = args?[0] as int?;
-      final result = id == null ? ringing.isNotEmpty : ringing.contains(id);
-      return <Object?>[result];
-    });
-    _handle('setWarningNotificationOnKill', (_) => <Object?>[null]);
-    _handle('disableWarningNotificationOnKill', (_) => <Object?>[null]);
-  }
-
-  void _handle(String name, Object? Function(List<Object?>? args) respond) {
-    final channel = BasicMessageChannel<Object?>(
-      '$_prefix$name',
-      AlarmApi.pigeonChannelCodec,
-    );
-    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-        .setMockDecodedMessageHandler<Object?>(channel, (message) async {
-      calls.add(name);
-      return respond(message as List<Object?>?);
-    });
-  }
-
-  void remove() {
-    for (final name in const [
-      'getPendingSnoozes',
-      'acknowledgeSnooze',
-      'setAlarm',
-      'stopAlarm',
-      'stopAll',
-      'isRinging',
-      'setWarningNotificationOnKill',
-      'disableWarningNotificationOnKill',
-    ]) {
-      final channel = BasicMessageChannel<Object?>(
-        '$_prefix$name',
-        AlarmApi.pigeonChannelCodec,
-      );
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockDecodedMessageHandler<Object?>(channel, null);
-    }
-  }
-}
+import 'support/fake_host.dart';
 
 /// Lets already-queued microtasks run.
 ///
@@ -95,7 +28,7 @@ Future<void> hostReportsSnooze(int alarmId, DateTime nextRingAt) async {
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  late _FakeHost host;
+  late FakeHost host;
 
   AlarmSettings buildAlarm(
     int id,
@@ -121,7 +54,7 @@ void main() {
     Alarm.resetForTesting();
     AlarmStorage.resetForTesting();
     AlarmTriggerApiImpl.resetForTesting();
-    host = _FakeHost()..install();
+    host = FakeHost()..install();
   });
 
   tearDown(() {

--- a/test/support/fake_host.dart
+++ b/test/support/fake_host.dart
@@ -1,0 +1,86 @@
+import 'package:alarm/src/generated/platform_bindings.g.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Stands in for the Android host over the real pigeon channels.
+///
+/// Several of the contracts worth testing are negotiations between Dart and the
+/// host rather than pure Dart logic — the host records a snooze marker and Dart
+/// applies it, or the host refuses to arm an alarm and Dart has to undo its own
+/// bookkeeping — so the interesting behaviour only shows up when both halves
+/// are present. Recording every call also lets a test assert what Dart did
+/// *not* do, which is what the reconciliation regressions are about.
+class FakeHost {
+  FakeHost();
+
+  final List<String> calls = <String>[];
+  final List<PendingSnoozeWire> pending = <PendingSnoozeWire>[];
+  final List<(int, int)> acknowledged = <(int, int)>[];
+  final Set<int> ringing = <int>{};
+
+  /// When set, `setAlarm` replies with this error instead of succeeding.
+  ///
+  /// A three-element reply is pigeon's error envelope, which the generated Dart
+  /// client turns into a `PlatformException`. That is the only way to reach the
+  /// Dart side of a host that stored an alarm but could not arm it. Use the raw
+  /// `AlarmErrorCode` index as the code, the way the host does.
+  ({String code, String message})? setAlarmError;
+
+  static const _prefix = 'dev.flutter.pigeon.alarm.AlarmApi.';
+
+  static const _methods = <String>[
+    'getPendingSnoozes',
+    'acknowledgeSnooze',
+    'setAlarm',
+    'stopAlarm',
+    'stopAll',
+    'isRinging',
+    'setWarningNotificationOnKill',
+    'disableWarningNotificationOnKill',
+  ];
+
+  void install() {
+    _handle('getPendingSnoozes', (_) => <Object?>[pending.toList()]);
+    _handle('acknowledgeSnooze', (args) {
+      acknowledged.add((args![0]! as int, args[1]! as int));
+      return <Object?>[null];
+    });
+    _handle('setAlarm', (_) {
+      final error = setAlarmError;
+      if (error != null) return <Object?>[error.code, error.message, null];
+      return <Object?>[null];
+    });
+    _handle('stopAlarm', (_) => <Object?>[null]);
+    _handle('stopAll', (_) => <Object?>[null]);
+    _handle('isRinging', (args) {
+      final id = args?[0] as int?;
+      final result = id == null ? ringing.isNotEmpty : ringing.contains(id);
+      return <Object?>[result];
+    });
+    _handle('setWarningNotificationOnKill', (_) => <Object?>[null]);
+    _handle('disableWarningNotificationOnKill', (_) => <Object?>[null]);
+  }
+
+  void _handle(String name, Object? Function(List<Object?>? args) respond) {
+    final channel = BasicMessageChannel<Object?>(
+      '$_prefix$name',
+      AlarmApi.pigeonChannelCodec,
+    );
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockDecodedMessageHandler<Object?>(channel, (message) async {
+      calls.add(name);
+      return respond(message as List<Object?>?);
+    });
+  }
+
+  void remove() {
+    for (final name in _methods) {
+      final channel = BasicMessageChannel<Object?>(
+        '$_prefix$name',
+        AlarmApi.pigeonChannelCodec,
+      );
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockDecodedMessageHandler<Object?>(channel, null);
+    }
+  }
+}


### PR DESCRIPTION
Fixes #419 and #420, both reported by @samyak1409 from a source reading rather than a device capture — because both failures are invisible by construction. Same class of bug: the plugin told the app an alarm was set when it was not.

Version and CHANGELOG are deliberately untouched, to be batched with the #421 decision.

## #420 — a failed arm was reported as success

`AlarmScheduler.schedule()` returns whether the alarm is *both stored and armed*, and its doc comment says so explicitly. The Pigeon caller discarded that boolean and replied `Result.success` unconditionally. Since `schedule()` saves *before* it arms, a failure left a phantom: stored, listed by `getAlarms()`, present in `Alarm.scheduled`, never armed, never rings.

The snooze path already handled this signal correctly (`SnoozeCoordinator` rolls back on `!scheduled`), which is what makes the Pigeon path an oversight rather than a design choice.

- `setAlarm(alarm)` now returns the boolean and stays policy-free, for the same reason `schedule()` is: what a failure *means* depends on the caller.
- The Pigeon override replies with `AlarmErrorCode.PLUGIN_INTERNAL`, sent as the **raw int** — Dart maps the code back with `int.tryParse`, so sending `.name` would arrive as `unknown`. Matches the existing iOS convention.
- It rolls back the halves that did land, so a phantom cannot outlive a process death before Dart's own cleanup runs (a survivor would be re-armed by `BootReceiver` after the next reboot — an alarm ringing that the app believes does not exist). Each step is isolated, so one failing cannot suppress the others, and the reply is reached whatever happens.
- `cancelPendingBroadcast` is extracted from `stopAlarm` and made non-throwing. That also hardens `stopAlarm`, which previously threw out of the Pigeon call and skipped its own unsave/refresh/notify when the service lookup failed.

**`BootReceiver` shares that helper and needs the opposite policy.** Native storage is the only record it re-arms from, no engine is running to receive an error, and a boot-time failure is often transient. So it keeps the alarm stored and logs. Dropping it there would silently lose the user's alarm for good.

Reachability: this is not only the defensive `ClassCastException` branch. `AlarmManager` enforces a per-app quota on scheduled alarms, past which `setExact*` throws `IllegalStateException` — reachable by any app pre-scheduling recurring alarms.

## #419 — `checkAlarm()` cancelled an alarm that was due but not yet ringing

`"already fired and was stopped"` and `"due, but the sound has not started yet"` were indistinguishable, and both ended at `stop(alarm.id)`, which cancels the pending `AlarmManager` entry and unsaves the alarm.

An alarm is not audible at its due instant: the broadcast has to be delivered, the process may have to start, the foreground service has to come up and the player has to prepare — and `isRinging` reads `ringingAlarmIds`, which is only assigned at the end of all that. A reconciliation landing in the gap cancelled a ring that was on its way.

It matters because Dart statics are per-isolate, so `Alarm.init()` runs again in every background isolate — an isolate whose first `init()` lands on the alarm minute runs straight over the pending ring.

Past-due alarms now get a 30-second grace on Android before being stopped. The comment is explicit that a spared alarm is *not* tidied up on a timer, and that it is an accepted risk rather than a harmless one.

## Also

Corrects a misleading log in `armAlarmManager`: the `IllegalStateException` branch reported `"AlarmManager service not available"` for what is really AlarmManager *refusing* the alarm (a missing service was our own throw two lines above). A `ClassCastException` branch that `as?` had made unreachable is removed — any CCE still lands in the generic catch and still returns `false`.

## Testing

`flutter analyze` clean, 79 Dart tests pass, `:alarm:compileDebugKotlin` clean.

New `test/alarm_check_test.dart` covers the grace window, the outside-the-window stop, the ringing branch, iOS behaviour, and the `set()` failure contract. `_FakeHost` moved to `test/support/fake_host.dart` so both suites share it. The grace tests were confirmed to have teeth: with `_ringStartGrace` set to `Duration.zero` the first one fails with `Actual: [..., 'stopAlarm']`.

**Note on coverage:** the Dart failure test injects the Pigeon error, so it exercises the existing Dart catch and would pass with the Kotlin change reverted. Nothing in `flutter test` observes the discarded boolean, the rollback, or the reboot policy. There is no Kotlin test source set; those were verified on device instead.

### Device QA — Pixel 8a, Android 16

Regressions: alarm armed exact and rang on time; delete-while-pending cancelled the entry and nothing rang at its time; snooze from the notification re-armed and rang again; notification Stop action; `STOP ALL`; and a real reboot re-armed a stored alarm.

**#419, A/B.** Held the race open by temporarily arming 20s after the stored time, then killed the process with `am kill` (which, unlike `force-stop`, leaves alarms armed) and relaunched inside the window.

With the fix — stored 17:06:00, armed 17:06:20, relaunch at 17:06:03:
```
17:06:06 [Alarm] Alarm 9295 came due 6584ms ago and is not audible yet, so it is left alone rather than stopped.
17:06:20.222 Alarm rang notification for 9295
```
With `lib/alarm.dart` reverted, same setup, relaunch at 17:09:03:
```
17:09:06 Alarm stopped notification for 8872
```
0 pending entries, and it never rang.

**#420.** Forced the arm to fail *after* `PendingIntent.getBroadcast`, toggled at runtime via a global setting (reinstalling an APK cancels the app's alarms, so a rebuild between steps would have invalidated the test).

- Failed `set()`: no `scheduled successfully` log — that line is exactly the lie. Dart tore it down, 0 pending entries, 0 native storage rows.
- Failed *replacement* of an armed alarm: 0 pending, 0 storage, and nothing rang at the original time.
- Reboot with arming failing:
```
E/BootReceiver: Failed to re-arm alarm 4855 after reboot. It stays stored so a later Alarm.init() or reboot can retry.
```
  The storage row survived. With the failure cleared, launching the app produced `Alarm with id 4855 scheduled successfully at 2026-08-06 17:17:00` — so keeping the alarm stored is what makes recovery possible.

Native storage was read directly (`run-as` on the DataStore file) rather than through `getAlarms()`, which reads Dart's separate store and would prove nothing about the rollback.

**Not verified:** audio was not confirmed by ear (verified via `AudioService`/`AlarmService` logs and the ring UI). And the stale-`PendingIntent` case that the rollback's cancel defends against is not reachable through the public API — `Alarm.set()` stops the same-id alarm before the new arm is attempted, so the old entry is already cancelled by the time a failure occurs. It is cheap defense-in-depth for a native-only caller, not something covered here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
