### PR TITLE
fix(android): restore the ring notification instead of ignoring the swipe (#421)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 5.9.0
+* [Android] Fixed `Alarm.init()` cancelling an alarm that was due but had not started ringing yet, which silently lost the alarm. Past-due alarms are now left alone for 30 seconds before being stopped.
+* [Android] A failed alarm arm is now reported to Flutter as an error instead of success, and no longer leaves an alarm stored that the platform never armed. **`Alarm.set()` now throws `AlarmException` where it previously returned `true`.** A failed re-arm after a reboot keeps the alarm stored instead, so a later `Alarm.init()` can retry it.
+* [Android] `NotificationSettings.androidStopAlarmOnDismiss: false` now re-posts the notification while the alarm is still ringing, instead of letting the swipe remove the only on-screen control over a sounding alarm.
+
 ## 5.8.0
 * [Android] Added `NotificationSettings.androidStopAlarmOnDismiss` to control whether swiping the notification away also stops the alarm. Enabled by default, matching the behavior added in 5.0.3.
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ await Alarm.setWarningNotificationOnKill(title, body)
 
 The property `androidStopAlarmOnTermination` works only on Android as on iOS the alarm is naturally stopped by the system when the app is terminated (as the native code can no longer run).
 
-Since Android 13, a foreground service notification can be swiped away by the user, so the alarm notification is dismissible even though it is marked ongoing. By default that swipe stops the alarm, exactly like the stop button. Set `NotificationSettings.androidStopAlarmOnDismiss` to `false` if a stray swipe must not be able to silence an alarm — be aware that the notification is then gone while the alarm keeps ringing, so your app should offer another way to stop it — for example a dedicated ringing screen, as described in [Presenting the alarm on your own screen](#presenting-the-alarm-on-your-own-screen).
+Since Android 13, a foreground service notification can be swiped away while the device is unlocked, so the alarm notification is dismissible even though it is marked ongoing. By default that swipe stops the alarm, exactly like the stop button. Set `NotificationSettings.androidStopAlarmOnDismiss` to `false` if a stray swipe must not be able to silence an alarm: the swipe then re-posts the notification for as long as the alarm is still ringing, so the user keeps the controls they need to act on it. Give the notification a `stopButton` so there is something to act with, or present the alarm on [your own screen](#presenting-the-alarm-on-your-own-screen).
 
 ### NotificationSettings model
 

--- a/android/src/main/kotlin/com/gdelataillade/alarm/alarm/AlarmReceiver.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/alarm/AlarmReceiver.kt
@@ -17,6 +17,7 @@ class AlarmReceiver : BroadcastReceiver() {
 
         const val ACTION_ALARM_STOP = "com.gdelataillade.alarm.ACTION_STOP"
         const val ACTION_ALARM_SNOOZE = "com.gdelataillade.alarm.ACTION_SNOOZE"
+        const val ACTION_ALARM_RESTORE = "com.gdelataillade.alarm.ACTION_RESTORE"
     }
 
     override fun onReceive(context: Context, intent: Intent) {
@@ -41,6 +42,17 @@ class AlarmReceiver : BroadcastReceiver() {
                     Log.d(TAG, "Alarm stopped notification for $id processed by Flutter: ${it.isSuccess}")
                 }
             }
+            return
+        }
+
+        // Put the notification back after the user swiped it away, which is what
+        // androidStopAlarmOnDismiss = false means: the swipe must not be able to
+        // silence the alarm, and it must not be able to take away the controls
+        // either. The service decides whether the alarm is still ringing.
+        if (intent.action == ACTION_ALARM_RESTORE) {
+            val id = intent.getIntExtra("id", 0)
+            Log.d(TAG, "Received restore notification command, id: $id")
+            if (id != 0) AlarmService.instance?.restoreNotification(id)
             return
         }
 

--- a/android/src/main/kotlin/com/gdelataillade/alarm/alarm/AlarmService.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/alarm/AlarmService.kt
@@ -386,6 +386,39 @@ class AlarmService : Service() {
     }
 
     /**
+     * Re-posts the ring notification for [alarmId] after the user swiped it away.
+     *
+     * Only for [AlarmReceiver], and only reached when the alarm set
+     * `androidStopAlarmOnDismiss = false`. Dismissing a foreground service
+     * notification does not stop the service, so without this the alarm keeps
+     * sounding with nothing on screen to act on it.
+     *
+     * Does nothing unless this service is currently ringing [alarmId] and owns its
+     * notification, so a dismissal that races the alarm ending cannot resurrect a
+     * notification for an alarm that is over. That guard also matters because
+     * [AlarmReceiver] is exported and the action can therefore be broadcast by
+     * anything.
+     */
+    fun restoreNotification(alarmId: Int) {
+        if (!ringingAlarmIds.contains(alarmId)) {
+            Log.d(TAG, "Not restoring the notification for $alarmId: it is not ringing.")
+            return
+        }
+
+        val notification = currentForegroundNotification
+        if (currentForegroundId != alarmId || notification == null) {
+            Log.d(TAG, "Not restoring the notification for $alarmId: this service does not own it.")
+            return
+        }
+
+        // Re-posted through startForeground rather than the notification manager so
+        // the notification stays owned by the service, and stopForeground still
+        // removes it when the alarm ends.
+        startAlarmService(alarmId, notification)
+        Log.d(TAG, "Restored the ring notification for $alarmId after a dismissal.")
+    }
+
+    /**
      * Silences [alarmId] without unsaving it or telling Flutter it stopped.
      *
      * Only for [SnoozeCoordinator], and only once it has armed the replacement:

--- a/android/src/main/kotlin/com/gdelataillade/alarm/services/NotificationService.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/services/NotificationService.kt
@@ -46,6 +46,26 @@ class NotificationHandler(private val context: Context) {
         notificationManager.cancel(id)
     }
 
+    /**
+     * Delete intent that puts the notification for [alarmId] back.
+     *
+     * Shares the alarm id as request code with the stop and snooze intents, which
+     * is safe because `PendingIntent` identity includes the action: only the
+     * extras are ignored.
+     */
+    private fun restorePendingIntent(alarmId: Int): PendingIntent {
+        val restoreIntent = Intent(context, AlarmReceiver::class.java).apply {
+            action = AlarmReceiver.ACTION_ALARM_RESTORE
+            putExtra("id", alarmId)
+        }
+        return PendingIntent.getBroadcast(
+            context,
+            alarmId,
+            restoreIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+    }
+
     // We need to use [Resources.getIdentifier] because resources are registered by Flutter.
     @SuppressLint("DiscouragedApi")
     fun buildNotification(
@@ -96,11 +116,21 @@ class NotificationHandler(private val context: Context) {
             .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
 
         // setOngoing(true) above no longer pins the notification: since Android 13 a
-        // foreground service notification can be swiped away, and this delete intent
-        // is what turns that swipe into a stop.
-        if (notificationSettings.androidStopAlarmOnDismiss) {
-            notificationBuilder.setDeleteIntent(stopPendingIntent)
-        }
+        // foreground service notification can be swiped away while the device is
+        // unlocked. The delete intent is the only signal Android gives for that
+        // swipe, so it is what decides what the swipe means.
+        //
+        // Opting out has to *restore* rather than ignore. Ignoring it leaves the
+        // alarm sounding with its only on-screen control gone, which is worse than
+        // the stray swipe the opt-out exists to prevent; re-posting extends to an
+        // unlocked device what the platform already guarantees on a locked one.
+        notificationBuilder.setDeleteIntent(
+            if (notificationSettings.androidStopAlarmOnDismiss) {
+                stopPendingIntent
+            } else {
+                restorePendingIntent(alarmId)
+            }
+        )
 
         if (fullScreen) {
             notificationBuilder.setFullScreenIntent(pendingIntent, true)

--- a/example/lib/screens/home.dart
+++ b/example/lib/screens/home.dart
@@ -11,7 +11,7 @@ import 'package:alarm_example/widgets/tile.dart';
 import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-const version = '5.8.0';
+const version = '5.9.0';
 
 class ExampleAlarmHomeScreen extends StatefulWidget {
   const ExampleAlarmHomeScreen({super.key});

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "5.8.0"
+    version: "5.9.0"
   args:
     dependency: transitive
     description:

--- a/lib/alarm.dart
+++ b/lib/alarm.dart
@@ -302,9 +302,9 @@ class Alarm {
         notification.stopButton == null) {
       _log.warning(
         'Alarm ${alarmSettings.id} turns off androidStopAlarmOnDismiss and '
-        'sets no stopButton, so its notification offers no way to stop the '
-        'alarm. Give it a stopButton, or present the alarm on a screen of '
-        'your own.',
+        'sets no stopButton, so its notification comes back after a swipe but '
+        'still offers no way to stop the alarm. Give it a stopButton, or '
+        'present the alarm on a screen of your own.',
       );
     }
   }

--- a/lib/model/notification_settings.dart
+++ b/lib/model/notification_settings.dart
@@ -101,14 +101,18 @@ class NotificationSettings extends Equatable {
   /// **Android only.** iOS has no equivalent dismissal action.
   ///
   /// Android 13 made foreground service notifications user-dismissible, so
-  /// `setOngoing(true)` no longer keeps the alarm notification pinned: it can
-  /// be swiped out of the shade like any other. When this is `true` that swipe
-  /// runs the same stop action as the notification's stop button.
+  /// `setOngoing(true)` no longer keeps the alarm notification pinned while the
+  /// device is unlocked: it can be swiped out of the shade like any other. When
+  /// this is `true` that swipe runs the same stop action as the notification's
+  /// stop button.
   ///
   /// Set it to `false` if a stray swipe must not be able to silence an alarm.
-  /// Note that the notification is then gone while the alarm keeps ringing, so
-  /// the app should offer another way to stop it (for example a ringing screen
-  /// of its own, reachable from the launcher).
+  /// The swipe then puts the notification straight back, for as long as the
+  /// alarm is still ringing, so it cannot take away the controls the user needs
+  /// to act on it — give the notification a [stopButton] so there is something
+  /// to act with. This extends to an unlocked device what the platform already
+  /// guarantees on a locked one, where an ongoing notification cannot be
+  /// dismissed at all.
   ///
   /// Defaults to `true`, which is how the plugin has behaved since 5.0.3.
   final bool androidStopAlarmOnDismiss;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: alarm
 description: A simple Flutter alarm manager plugin for both iOS and Android.
-version: 5.8.0
+version: 5.9.0
 homepage: https://github.com/gdelataillade/alarm
 
 environment:

--- a/test/alarm_validation_test.dart
+++ b/test/alarm_validation_test.dart
@@ -136,8 +136,8 @@ void main() {
     });
 
     test('warns when a dismiss-proof notification offers no stop button', () {
-      // Both together leave the notification with no stop affordance at all:
-      // no action button, and no delete intent behind the swipe.
+      // The swipe restores the notification rather than stopping the alarm, so
+      // with no action button either there is no stop affordance at all.
       final records = captureLogs();
 
       expect(


### PR DESCRIPTION
Fixes #421, reported by @samyak1409 as a follow-up to their own #413 — "I asked for the wrong half".

**Stacked on #422**, so this diff shows only the #421 work. GitHub will retarget it to `main` once #422 merges. It also carries the 5.9.0 release for all three issues, per the single-release decision.

## The problem

`androidStopAlarmOnDismiss: false` meant "the swipe does nothing". The notification went away and the alarm kept sounding with no Stop control anywhere — worse than the stray swipe the opt-out exists to prevent, since it removes the only control the user has over an alarm that is still going. The documented workaround (a ringing screen of your own, reachable from the launcher) means hunting for the app while the alarm blares.

It cannot be fixed app-side, which I verified: the delete intent is built inside the plugin, and `AlarmPlugin.alarmTriggerApi` is engine-scoped, so with the app closed — the whole point of an alarm — Dart is never told the alarm is ringing at all.

Scope is genuinely narrow, as the reporter was careful to say: `setOngoing(true)` still pins the notification while the device is **locked**, so the 6am-on-the-nightstand case was never affected. This is the unlocked case, where Android shows a heads-up instead of launching the full-screen intent.

## The change

The swipe now re-posts the notification for as long as the alarm is still ringing. No API change, and the flag name stays truthful — dismissing still does not stop the alarm. It extends to an unlocked device what the platform already guarantees on a locked one.

- `NotificationService` always sets a delete intent now, choosing between the stop intent and a new `restorePendingIntent`. Sharing the alarm id as request code is safe because `PendingIntent` identity includes the action.
- `AlarmReceiver` gains `ACTION_ALARM_RESTORE`, returning early so it cannot fall through to the ring path.
- `AlarmService.restoreNotification(id)` re-posts the already-cached `currentForegroundNotification` through `startForeground`, so the notification stays owned by the service and `stopForeground` still removes it when the alarm ends.

Double-gated on the service both ringing that alarm (`ringingAlarmIds`) **and** owning its notification (`currentForegroundId`), so a dismissal racing the alarm ending cannot resurrect a notification for an alarm that is over. That guard also matters because `AlarmReceiver` is exported, so the action can be broadcast by anything.

Chose this over a three-state enum (`stop` / `ignore` / `restore`): nobody wants "notification gone, alarm ringing, no control", and a bool→enum migration on a published API one release after shipping it is churn for a distinction no one asked for.

Docs updated in three places — the flag's doc comment, the README section, and the validation warning, which now reads "comes back after a swipe but still offers no way to stop the alarm" (it still fires when `false` is set with no `stopButton`, because a restored notification without one has no stop affordance).

## Testing

`flutter analyze` clean, 79 tests pass, `:alarm:compileDebugKotlin` clean.

No new unit test: the behaviour is entirely in the native notification layer, which has no test source set. Verified on a Pixel 8a (Android 16) instead, with the example app temporarily setting the flag to `false`. All five things I wanted to rule out:

1. **Swipe while ringing restores it.** The notification came back in place with both actions, and the alarm kept sounding:
```
12:43:38.242 D/AlarmReceiver: Received restore notification command, id: 8903
12:43:38.250 D/AlarmService: Restored the ring notification for 8903 after a dismissal.
```
2. **Re-posting does not re-fire the full-screen intent.** The notification carries `setFullScreenIntent`, so this was the main risk. The activity-`Displayed` count was unchanged across the restore.
3. **Tapping does not fire the delete intent.** `setAutoCancel(true)` is set, so a tap could have triggered a pointless restore — it does not. (Which also means the `true` path never had a latent "tap stops the alarm" bug.)
4. **"Clear all" never reaches this path at all.** Android excludes ongoing foreground service notifications from it: the alarm notification was left untouched while other notifications cleared, and no delete intent fired. So restore does not fight the user's clear-all.
5. **A hostile or late broadcast is refused.** An external `am broadcast` of `ACTION_RESTORE` with nothing ringing, and one sent right after the alarm was stopped, both produced no restore and no live notification.

## Release

5.9.0 covers all three issues. `pubspec.yaml`, the example's `version` constant and `example/pubspec.lock` are bumped together, matching how previous releases did it. The CHANGELOG calls out in bold that `Alarm.set()` now throws where it previously returned `true`, since that is the one observable change an existing app could trip over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
