### PR TITLE
fix(android): retry a refused ring instead of losing the alarm (#424)

### DIFF
--- a/android/src/main/kotlin/com/gdelataillade/alarm/alarm/AlarmService.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/alarm/AlarmService.kt
@@ -16,9 +16,14 @@ import android.os.IBinder
 import android.os.PowerManager
 import android.os.Build
 import androidx.core.app.ServiceCompat
+import com.gdelataillade.alarm.models.AlarmEventCause
+import com.gdelataillade.alarm.models.AlarmEventVerb
 import com.gdelataillade.alarm.models.AlarmSettings
+import com.gdelataillade.alarm.models.HostAlarmEvent
 import com.gdelataillade.alarm.models.NotificationSettings
 import com.gdelataillade.alarm.services.AlarmRingingLiveData
+import com.gdelataillade.alarm.services.AlarmScheduler
+import java.util.Date
 import com.gdelataillade.alarm.services.NotificationHandler
 import com.gdelataillade.alarm.services.WarningNotificationState
 import com.gdelataillade.alarm.services.SnoozeCoordinator
@@ -32,6 +37,22 @@ class AlarmService : Service() {
         // Arbitrary non-zero id used when the service must enter the
         // foreground without a real alarm notification to show.
         private const val PLACEHOLDER_NOTIFICATION_ID = 973_422
+
+        /**
+         * How far out to re-arm a ring the platform refused to let us start.
+         *
+         * Android 15 forbids starting a `mediaPlayback` foreground service from
+         * `BOOT_COMPLETED`, and the restriction follows the attribution: while
+         * the boot allowlist is open — 20s from when `BootReceiver` runs — every
+         * foreground service start by the app inherits it, including one an
+         * ordinary `AlarmManager` delivery triggered. Waiting the window out and
+         * letting `AlarmManager` deliver again gets the start attributed to the
+         * exact-alarm exemption instead, which is allowed.
+         *
+         * 30s rather than 20s so a slow boot cannot land the retry back inside
+         * the window it is trying to escape.
+         */
+        private const val RING_RETRY_DELAY_MILLIS = 30_000L
 
         /**
          * Action an application declares on the activity that should present a
@@ -170,7 +191,11 @@ class AlarmService : Service() {
                 try {
                     startAlarmService(id, notification)
                 } catch (e: ForegroundServiceStartNotAllowedException) {
-                    Log.e(TAG, "Foreground service start not allowed", e)
+                    // Returning here is what made the alarm vanish in silence:
+                    // the service stays up, never foregrounded, with no
+                    // notification and no audio, and nothing tells Dart.
+                    Log.e(TAG, "Foreground service start not allowed; deferring the ring", e)
+                    deferRefusedRing(id, alarmSettings)
                     return
                 }
             } else {
@@ -383,6 +408,130 @@ class AlarmService : Service() {
     fun handleStopAlarmCommand(alarmId: Int) {
         if (alarmId == 0) return
         unsaveAlarm(alarmId)
+    }
+
+    /**
+     * Re-arms [alarmSettings] shortly in the future after the platform refused to
+     * let this ring enter the foreground.
+     *
+     * The refusal is not the alarm's fault and not recoverable in the moment, so
+     * the only honest options are to lose the alarm or to ring it late. Late is
+     * better: an alarm that sounds 30 seconds after a reboot is a far smaller
+     * failure than one that never sounds at all.
+     *
+     * Goes through [AlarmScheduler] so the shifted time is persisted as well as
+     * armed. That matters because Dart's reconciliation stops any alarm it finds
+     * past due, so a retry armed without moving the stored time would be
+     * cancelled by the next `Alarm.init()`.
+     */
+    private fun deferRefusedRing(alarmId: Int, alarmSettings: AlarmSettings) {
+        val storage = AlarmStorage(this)
+
+        // One retry is enough by construction: the boot allowlist lasts about
+        // 20s from when `BootReceiver` runs and the retry is armed 30s out, so
+        // it lands outside the window. A second refusal means the boot window
+        // was never the cause, and deferring again would postpone the same
+        // failure forever — 30s at a time, with the user hearing nothing.
+        //
+        // The check has to be durable rather than a counter on this class. By
+        // the time the retry fires, 30s later, this process holds no foreground
+        // service — the refused one stopped itself — so it is an ordinary
+        // background process the system may reclaim at any moment, and boot is
+        // when it is most likely to. In-memory state would then reset between a
+        // refusal and its own retry and never reach the limit. The marker the
+        // first deferral wrote is what survives that.
+        val alreadyDeferred = storage.getPendingAlarmEvents().any {
+            it.alarmId == alarmId &&
+                it.verb == AlarmEventVerb.MOVED &&
+                it.cause == AlarmEventCause.PLATFORM_REFUSAL
+        }
+        if (alreadyDeferred) {
+            dropRefusedRing(alarmId, alarmSettings, storage)
+            return
+        }
+
+        val recordedAt = System.currentTimeMillis()
+        val retryAt = recordedAt + RING_RETRY_DELAY_MILLIS
+        val deferred = alarmSettings.copy(dateTime = Date(retryAt))
+        val event = HostAlarmEvent(
+            alarmId = alarmId,
+            verb = AlarmEventVerb.MOVED,
+            cause = AlarmEventCause.PLATFORM_REFUSAL,
+            atMillis = retryAt,
+            recordedAtMillis = recordedAt,
+        )
+
+        // Recorded before arming, the same ordering SnoozeCoordinator uses: a
+        // crash in between still leaves Dart able to learn the alarm moved, and
+        // without that its reconciliation stops the alarm and cancels the retry.
+        storage.saveAlarmEvent(event)
+
+        if (!AlarmScheduler.schedule(this, deferred, requireDurable = true)) {
+            // The marker now describes a retry that is not armed.
+            storage.clearAlarmEvent(alarmId)
+            Log.e(TAG, "Could not re-arm the refused ring for $alarmId.")
+            dropRefusedRing(alarmId, alarmSettings, storage)
+            return
+        }
+
+        Log.d(TAG, "Ring for $alarmId deferred to $retryAt after a refused foreground start.")
+        reportHostEvent(event, storage)
+
+        // Nothing is ringing, so leave no service behind holding a foreground
+        // obligation it was never allowed to meet.
+        stopSelfIfIdle()
+    }
+
+    /**
+     * Gives up on a ring the platform will not allow, and says so.
+     *
+     * Reached when a retry is refused too, which means waiting out the boot
+     * window was not the answer. The alarm cannot ring and nothing here can make
+     * it, so the choice is between losing it silently and losing it visibly.
+     * Recording a drop is what lets the application tell its user that an alarm
+     * they set did not go off — the plugin deliberately says nothing itself.
+     */
+    private fun dropRefusedRing(
+        alarmId: Int,
+        alarmSettings: AlarmSettings,
+        storage: AlarmStorage,
+    ) {
+        val event = HostAlarmEvent(
+            alarmId = alarmId,
+            verb = AlarmEventVerb.DROPPED,
+            cause = AlarmEventCause.PLATFORM_REFUSAL,
+            atMillis = alarmSettings.dateTime.time,
+            recordedAtMillis = System.currentTimeMillis(),
+        )
+
+        // Order is free here: unsaveAlarm deliberately keeps DROPPED markers, so
+        // the record survives the removal it describes.
+        storage.saveAlarmEvent(event)
+        storage.unsaveAlarm(alarmId)
+
+        Log.e(
+            TAG,
+            "Ring for $alarmId was refused again; dropping the alarm and reporting it."
+        )
+        reportHostEvent(event, storage)
+        stopSelfIfIdle()
+    }
+
+    /**
+     * Tells Dart about [event] if an engine happens to be attached.
+     *
+     * Usually there is none — these refusals happen at boot — so the durable
+     * marker is the real delivery path and this is only an optimisation. The
+     * marker is dropped only once Dart confirms it applied the event.
+     */
+    private fun reportHostEvent(event: HostAlarmEvent, storage: AlarmStorage) {
+        AlarmPlugin.alarmTriggerApi?.alarmEvent(event.toWire()) { result ->
+            if (result.isSuccess) {
+                storage.acknowledgeAlarmEvent(event.alarmId, event.recordedAtMillis)
+            } else {
+                Log.d(TAG, "Dart did not apply the event for ${event.alarmId}; keeping the marker.")
+            }
+        }
     }
 
     /**

--- a/android/src/main/kotlin/com/gdelataillade/alarm/generated/FlutterBindings.g.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/generated/FlutterBindings.g.kt
@@ -129,12 +129,14 @@ enum class AlarmEventCauseWire(val raw: Int) {
   /** The user deferred the alarm from the notification or the ring screen. */
   SNOOZE(0),
   /**
-   * The platform refused to let the ring start, so it was re-armed later.
+   * The platform refused to let the ring start.
    *
    * Android forbids starting a `mediaPlayback` foreground service from
    * `BOOT_COMPLETED`, and the refusal follows the attribution rather than the
    * caller, so an ordinary alarm delivered inside the boot window is refused
-   * too. Ringing late beats not ringing.
+   * too. The alarm is normally re-armed just past that window, because ringing
+   * late beats not ringing; it is only dropped when the retry is refused as
+   * well, which means the boot window was not the cause.
    */
   PLATFORM_REFUSAL(1),
   /**

--- a/ios/alarm/Sources/alarm/generated/FlutterBindings.g.swift
+++ b/ios/alarm/Sources/alarm/generated/FlutterBindings.g.swift
@@ -163,12 +163,14 @@ enum AlarmEventVerbWire: Int {
 enum AlarmEventCauseWire: Int {
   /// The user deferred the alarm from the notification or the ring screen.
   case snooze = 0
-  /// The platform refused to let the ring start, so it was re-armed later.
+  /// The platform refused to let the ring start.
   ///
   /// Android forbids starting a `mediaPlayback` foreground service from
   /// `BOOT_COMPLETED`, and the refusal follows the attribution rather than the
   /// caller, so an ordinary alarm delivered inside the boot window is refused
-  /// too. Ringing late beats not ringing.
+  /// too. The alarm is normally re-armed just past that window, because ringing
+  /// late beats not ringing; it is only dropped when the retry is refused as
+  /// well, which means the boot window was not the cause.
   case platformRefusal = 1
   /// The alarm's time had already passed while the device was off, so it was
   /// discarded at boot rather than sounded hours late.

--- a/lib/model/alarm_event.dart
+++ b/lib/model/alarm_event.dart
@@ -6,12 +6,15 @@ enum AlarmEventCause {
   /// The user deferred the alarm from the notification or the ring screen.
   snooze,
 
-  /// The platform refused to let the ring start, so it was re-armed later.
+  /// The platform refused to let the ring start.
   ///
   /// Android forbids starting a media playback foreground service from
   /// `BOOT_COMPLETED`, and the refusal follows the attribution rather than the
   /// caller, so an ordinary alarm delivered inside the boot window is refused
-  /// too. Ringing late beats not ringing.
+  /// too. Paired with [AlarmMoved] the alarm was re-armed just past that
+  /// window, because ringing late beats not ringing. Paired with [AlarmDropped]
+  /// the retry was refused as well, which means the boot window was not the
+  /// cause and waiting longer would not have helped.
   platformRefusal,
 
   /// The alarm's time had already passed while the device was off, so it was

--- a/lib/src/generated/platform_bindings.g.dart
+++ b/lib/src/generated/platform_bindings.g.dart
@@ -78,12 +78,14 @@ enum AlarmEventCauseWire {
   /// The user deferred the alarm from the notification or the ring screen.
   snooze,
 
-  /// The platform refused to let the ring start, so it was re-armed later.
+  /// The platform refused to let the ring start.
   ///
   /// Android forbids starting a `mediaPlayback` foreground service from
   /// `BOOT_COMPLETED`, and the refusal follows the attribution rather than the
   /// caller, so an ordinary alarm delivered inside the boot window is refused
-  /// too. Ringing late beats not ringing.
+  /// too. The alarm is normally re-armed just past that window, because ringing
+  /// late beats not ringing; it is only dropped when the retry is refused as
+  /// well, which means the boot window was not the cause.
   platformRefusal,
 
   /// The alarm's time had already passed while the device was off, so it was

--- a/pigeons/alarm_api.dart
+++ b/pigeons/alarm_api.dart
@@ -204,12 +204,14 @@ enum AlarmEventCauseWire {
   /// The user deferred the alarm from the notification or the ring screen.
   snooze,
 
-  /// The platform refused to let the ring start, so it was re-armed later.
+  /// The platform refused to let the ring start.
   ///
   /// Android forbids starting a `mediaPlayback` foreground service from
   /// `BOOT_COMPLETED`, and the refusal follows the attribution rather than the
   /// caller, so an ordinary alarm delivered inside the boot window is refused
-  /// too. Ringing late beats not ringing.
+  /// too. The alarm is normally re-armed just past that window, because ringing
+  /// late beats not ringing; it is only dropped when the retry is refused as
+  /// well, which means the boot window was not the cause.
   platformRefusal,
 
   /// The alarm's time had already passed while the device was off, so it was


### PR DESCRIPTION
Fixes #424. Stage 3 of the plan on #418, built on the event plumbing from #425.

## The bug

Android forbids starting a `mediaPlayback` foreground service from `BOOT_COMPLETED`, and the refusal follows the *attribution* rather than the caller — so while the boot allowlist is open, an ordinary `AlarmManager` delivery is refused too. `AlarmService.ringAlarm` caught the exception, logged it, and returned:

```kotlin
} catch (e: ForegroundServiceStartNotAllowedException) {
    Log.e(TAG, "Foreground service start not allowed", e)
    return
}
```

That left the service running but never foregrounded — no notification, no audio, nothing reported to Dart, and the alarm still in storage as though it had rung.

## The fix

**Defer and retry.** The refusal now re-arms the ring 30s out through `AlarmScheduler`, which gets the retry attributed to the exact-alarm exemption instead. 30s rather than 20s so a slow boot cannot land the retry back inside the window it is escaping.

**Record it before arming.** A `moved`/`platformRefusal` marker is written first, the same ordering `SnoozeCoordinator` uses. Without it Dart's reconciliation finds a past-due alarm, stops it, and cancels the very retry it was meant to protect. This is why the fix needed #425 and could not land on its own.

**One retry, bounded durably.** 30s clears a 20s window by construction, so a second refusal means the boot window was never the cause, and deferring again would postpone the same silence forever. The check reads the marker the first deferral wrote rather than a counter on the service — by the time the retry fires, this process holds no foreground service and is an ordinary background process the system may already have reclaimed. I tried a counter first; see below.

**A second refusal drops the alarm and says so**, via `dropped`/`platformRefusal`. It cannot be made to ring either way, so the choice is between losing it silently and losing it visibly. The record is what lets an application tell its user an alarm did not go off; the plugin still posts nothing itself. This is the first real producer of `AlarmDropped`.

## What testing changed

**A process-scoped retry counter did not work, and the device found it.** With an in-memory `Set<Int>` the limit was never reached: the alarm deferred repeatedly, 30s at a time, from different pids. Replaced with the durable marker check.

Two honest caveats on that, because the evidence was not as clean as it looked:

- The process deaths I *observed* were caused by my own test stub, which threw before `startForeground()` and so never discharged the `startForegroundService()` obligation — the system then killed the process with `ForegroundServiceDidNotStartInTimeException`. That cannot happen on the real path, where the call is made and refused, which I verified separately discharges it.
- So the code comment no longer claims "at boot each delivery starts a fresh process", which the evidence does not support. It states what is defensible: by retry time the process holds no foreground service, so it may be reclaimed at any moment, and boot is when that is likeliest. The durable bound is right on that basis; the original justification was overstated.

## Verification

`flutter analyze` clean, 89 tests, `:alarm:compileDebugKotlin` clean.

No new Dart tests: #425 already covers both verbs and the `platformRefusal` cause through `FakeHost`, and the cause is pass-through data — the verb drives Dart's handling. Everything new here is Kotlin, which still has no test source set, so it was verified on hardware.

**Pixel 8a, Android 16.** Natural path, stale alarm at boot:

```
08:52:25.873  refused → deferring the ring
              __alarm_event__7179  "verb":"MOVED"  "cause":"PLATFORM_REFUSAL"
08:52:55.892  FGS allowed, code:ALARM_MANAGER_WHILE_IDLE
08:52:55.989  Using device default alarm sound
```

The case that previously broke it — launching the app *inside* the deferral window, which is what used to cancel the retry:

```
Dart stored dateTime = 2026-08-07T08:55:56.607   (the retry time; the move applied)
native marker        = 0                          (Dart acknowledged it)
rang at 08:55:56.732
```

Give-up path, with refusals forced:

```
09:04:00.154  pid 10103  refused → deferring
09:04:30.457  pid 10137  refused → fresh process, marker persisted
09:04:30.665             "refused again; dropping the alarm and reporting it."
              __alarm_event__9072  "verb":"DROPPED"  "cause":"PLATFORM_REFUSAL"
09:07:17.672  [Alarm] Alarm 9072 was dropped by the host (platformRefusal);
                      it should have rung at 09:04:30.257
```

with the alarm gone from Dart storage and the marker acknowledged.

## Not in this PR

- No version bump or CHANGELOG. Still batched: #425's `Alarm.events`, the buffered `Alarm.snoozed`, and this all want one release, and #418 may join it.
- The remaining exposure is an alarm refused for a reason other than the boot window — battery restrictions, say. It now fails visibly rather than silently, which is as far as this can go without a foreground service type the platform will allow from anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
