### PR TITLE
chore: release 5.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 5.10.0
+* [Android] Fixed an alarm due within roughly 45 seconds of a reboot never ringing. Android forbids starting a media playback foreground service from `BOOT_COMPLETED`, and the refusal follows the attribution rather than the caller, so an ordinary alarm delivered inside the boot window was refused too and vanished with no notification, no sound and nothing reported. Such a ring is now retried just past that window; if the retry is refused as well the alarm is dropped and reported rather than lost in silence.
+* Added `Alarm.events`, a stream of changes the host made to an alarm on its own: deferrals the platform forced, and alarms it discarded. Buffered, so subscribing after `Alarm.init()` still receives what was drained during it. Delivered at least once — key any irreversible reaction on `(id, recordedAt)`.
+* **`Alarm.snoozed` is now buffered**, and is a view over `Alarm.events`. A deferral taken with no Flutter engine running is applied during `Alarm.init()`, and previously reached only listeners that already existed — which the documented `await Alarm.init()` in `main` made unlikely. Existing listeners are unaffected; deferrals that used to be dropped now arrive.
+
 ## 5.9.0
 * [Android] Fixed `Alarm.init()` cancelling an alarm that was due but had not started ringing yet, which silently lost the alarm. Past-due alarms are now left alone for 30 seconds before being stopped.
 * [Android] A failed alarm arm is now reported to Flutter as an error instead of success, and no longer leaves an alarm stored that the platform never armed. **`Alarm.set()` now throws `AlarmException` where it previously returned `true`.** A failed re-arm after a reboot keeps the alarm stored instead, so a later `Alarm.init()` can retry it.

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:alarm/alarm.dart';
 import 'package:alarm_example/screens/home.dart';
 import 'package:alarm_example/utils/logging.dart';
@@ -12,20 +10,7 @@ Future<void> main() async {
 
   setupLogging(showDebugLogs: true);
 
-  // Subscribed before Alarm.init() on purpose. A snooze taken while the app was
-  // not running is replayed during init, and Alarm.snoozed is a plain broadcast
-  // stream, so a listener registered afterwards -- from a widget, say -- would
-  // miss it entirely.
-  final replayedSnoozes = <({int id, DateTime nextRingAt})>[];
-  final snoozeSubscription = Alarm.snoozed.listen(replayedSnoozes.add);
-
   await Alarm.init();
-
-  for (final snooze in replayedSnoozes) {
-    debugPrint('Replayed snooze: alarm ${snooze.id} rings at '
-        '${snooze.nextRingAt}');
-  }
-  await snoozeSubscription.cancel();
 
   runApp(
     MaterialApp(

--- a/example/lib/screens/home.dart
+++ b/example/lib/screens/home.dart
@@ -11,7 +11,7 @@ import 'package:alarm_example/widgets/tile.dart';
 import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-const version = '5.9.0';
+const version = '5.10.0';
 
 class ExampleAlarmHomeScreen extends StatefulWidget {
   const ExampleAlarmHomeScreen({super.key});
@@ -39,11 +39,9 @@ class _ExampleAlarmHomeScreenState extends State<ExampleAlarmHomeScreen> {
     updateSubscription = Alarm.scheduled.listen((_) {
       unawaited(loadAlarms());
     });
-    // Android only. This receives snoozes taken while the app is running.
-    // A snooze taken with no engine is replayed during Alarm.init(), which
-    // happens before this widget exists -- see main() for that half. Either
-    // way the alarm list below refreshes, because Alarm.scheduled replays its
-    // latest value to new listeners.
+    // Android only. Receives snoozes taken while the app is running, and also
+    // the ones replayed during Alarm.init() -- the stream is buffered, so
+    // subscribing from a widget built after init still delivers those.
     snoozeSubscription = Alarm.snoozed.listen(snoozed);
     notifications = Notifications();
   }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "5.9.0"
+    version: "5.10.0"
   args:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: alarm
 description: A simple Flutter alarm manager plugin for both iOS and Android.
-version: 5.9.0
+version: 5.10.0
 homepage: https://github.com/gdelataillade/alarm
 
 environment:


### PR DESCRIPTION
Release prep for 5.10.0. Version bump, CHANGELOG, and one example cleanup that the release makes necessary.

## What ships

Everything merged since 5.9.0 — #425 (host alarm events) and #426 (#424's boot-window fix):

- **The boot-window fix (#424).** An alarm due within roughly 45 seconds of a reboot never rang. Android forbids starting a media playback foreground service from `BOOT_COMPLETED`, and the refusal follows the attribution rather than the caller, so an ordinary `AlarmManager` delivery inside the window was refused too — no notification, no sound, nothing reported, and the alarm left in storage as though it had rung. Such a ring is now retried just past the window, and if the retry is refused as well the alarm is dropped and reported rather than lost silently.
- **`Alarm.events`**, reporting changes the host made to an alarm on its own. Buffered, delivered at least once, keyed by `(id, recordedAt)`.
- **`Alarm.snoozed` is now buffered**, called out in bold in the CHANGELOG because it is the one observable change to an already released API. Existing listeners are unaffected; deferrals that used to be dropped now arrive.

## Version, in three places plus the lock

`pubspec.yaml`, the example's `version` constant and `example/pubspec.lock` move together, matching how 5.9.0 was cut.

Minor rather than major: the new API is additive, and the `Alarm.snoozed` change delivers strictly more than before rather than breaking a signature.

## The example cleanup

`example/lib/main.dart` subscribed to `Alarm.snoozed` *before* `Alarm.init()`, collected whatever was replayed, printed it, then cancelled. Its own comment explained why: "Alarm.snoozed is a plain broadcast stream, so a listener registered afterwards -- from a widget, say -- would miss it entirely."

That is exactly the bug #425 fixed, so the workaround is now dead code that teaches the wrong thing in the file users copy from. Removed, along with the `dart:async` import nothing else needed. The home screen's own listener now covers replayed deferrals, which is the behaviour worth demonstrating, and its comment says so instead of pointing at `main()`.

Leaving that in would have shipped the fix and the workaround for it in the same release.

## Verification

`flutter analyze` clean for both the package and the example, 89 tests, `:alarm:compileDebugKotlin` clean.

`flutter pub publish --dry-run` reports only "4 checked-in files are modified in git", which is the uncommitted working tree at the time it ran and clears on commit. Nothing else.

## After merging

Publishing is manual, as with 5.9.0:

```
flutter pub publish
```

Two things worth knowing before you do:

- **Nobody has heard #426 ring by ear.** Audio was verified through `dumpsys audio` showing a started `USAGE_ALARM` player, which is solid evidence but not the same as listening — and this fix is specifically about alarms that previously made no sound. One manual alarm is cheap insurance.
- **#418 is not in this release.** The `staleAtBoot` cause therefore ships with no producer yet. Harmless, and it is the last piece of the three-part plan on #418, still waiting on the reporter for the staleness cutoff and the `AlarmDropped` payload question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
