### PR TITLE
test(android): add a Kotlin unit test source set, and run it in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,6 +64,21 @@ jobs:
       - name: Run Android unit tests
         working-directory: example/android
         run: ./gradlew :alarm:test
+      # A test task with no sources is NO-SOURCE, which is a *pass*. So the exit
+      # code alone cannot tell "17 tests green" from "the source set stopped
+      # being picked up" -- read the results and require that tests actually ran.
+      # Sound here because the checkout is clean, so no earlier run's results
+      # can stand in for this one's.
+      - name: Check the Android unit tests actually ran
+        run: |
+          python3 - <<'PY'
+          import glob, sys, xml.etree.ElementTree as ET
+          files = glob.glob("example/build/alarm/test-results/**/TEST-*.xml", recursive=True)
+          total = sum(int(ET.parse(f).getroot().get("tests", 0)) for f in files)
+          print(f"{len(files)} suites, {total} tests")
+          if total == 0:
+              sys.exit("No Android unit tests ran; the test source set is not being picked up.")
+          PY
       - name: Upload Android test report
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,3 +59,15 @@ jobs:
         run: |
           flutter pub get
           flutter build apk --debug
+      # After the APK build, which is what runs `flutter pub get` and generates
+      # the Gradle wiring the :alarm module needs to resolve.
+      - name: Run Android unit tests
+        working-directory: example/android
+        run: ./gradlew :alarm:test
+      - name: Upload Android test report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-test-report
+          path: example/build/alarm/reports/tests/
+          if-no-files-found: ignore

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -59,6 +59,17 @@ android {
             consumerProguardFiles 'proguard-rules.pro'
         }
     }
+
+    testOptions {
+        unitTests {
+            // The plugin logs through io.flutter.Log, which delegates to
+            // android.util.Log. Without this, every logging call in the code
+            // under test throws "not mocked" instead of doing nothing, which
+            // would force Robolectric on tests that otherwise need no Android
+            // framework at all.
+            returnDefaultValues = true
+        }
+    }
 }
 
 dependencies {
@@ -70,4 +81,9 @@ dependencies {
     // instead of relying on it transitively.
     implementation 'androidx.core:core:1.13.1'
     implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3'
+
+    // Unit tests run on the JVM, so they never reach a device or an emulator.
+    // testImplementation is not visible to consumers, and is only resolved when
+    // this module's own tests are compiled.
+    testImplementation 'junit:junit:4.13.2'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -61,13 +61,27 @@ android {
     }
 
     testOptions {
-        unitTests {
-            // The plugin logs through io.flutter.Log, which delegates to
-            // android.util.Log. Without this, every logging call in the code
-            // under test throws "not mocked" instead of doing nothing, which
-            // would force Robolectric on tests that otherwise need no Android
-            // framework at all.
-            returnDefaultValues = true
+        // The plugin logs through io.flutter.Log, which delegates to
+        // android.util.Log. Without this, every logging call in the code under
+        // test throws "not mocked" instead of doing nothing, which would force
+        // Robolectric on tests that otherwise need no Android framework at all.
+        unitTests.returnDefaultValues = true
+
+        unitTests.all { test ->
+            test.testLogging { exceptionFormat = 'full' }
+            test.afterSuite { descriptor, result ->
+                // Only the synthetic root suite has no parent.
+                if (descriptor.parent != null) return
+                logger.lifecycle("${test.name}: ${result.testCount} tests, " +
+                    "${result.failedTestCount} failed, ${result.skippedTestCount} skipped")
+                // A test task that finds nothing still succeeds, so a source set
+                // that silently stops being picked up -- an AGP upgrade, a moved
+                // directory -- would leave CI green while covering nothing.
+                if (result.testCount == 0) {
+                    throw new GradleException("${test.name} ran no tests. The test " +
+                        "source set is not being picked up.")
+                }
+            }
         }
     }
 }

--- a/android/src/main/kotlin/com/gdelataillade/alarm/services/AlarmStorage.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/services/AlarmStorage.kt
@@ -23,7 +23,17 @@ const val SHARED_PREFERENCES_NAME = "AlarmSharedPreferences"
 private val Context.dataStore: DataStore<Preferences> by
 preferencesDataStore(SHARED_PREFERENCES_NAME)
 
-class AlarmStorage(context: Context) {
+/**
+ * Durable storage for alarms and for the events the host records about them.
+ *
+ * Takes the `DataStore` rather than building it, so unit tests can hand it one
+ * over a temporary file and exercise the marker rules — the migration, the TTLs,
+ * the acknowledgement match, the verb-aware clearing — without a device.
+ */
+class AlarmStorage internal constructor(private val dataStore: DataStore<Preferences>) {
+    /** Production entry point: one process-wide store, keyed off the context. */
+    constructor(context: Context) : this(context.dataStore)
+
     companion object {
         private const val TAG = "AlarmStorage"
         private const val PREFIX = "__alarm_id__"
@@ -42,8 +52,6 @@ class AlarmStorage(context: Context) {
         private const val WARNING_TITLE_KEY = "notificationOnAppKillTitle"
         private const val WARNING_BODY_KEY = "notificationOnAppKillBody"
     }
-
-    private val dataStore = context.dataStore
 
     fun saveAlarm(alarmSettings: AlarmSettings) {
         return runBlocking {

--- a/android/src/test/kotlin/com/gdelataillade/alarm/models/HostAlarmEventTest.kt
+++ b/android/src/test/kotlin/com/gdelataillade/alarm/models/HostAlarmEventTest.kt
@@ -1,0 +1,69 @@
+package com.gdelataillade.alarm.models
+
+import com.gdelataillade.alarm.generated.AlarmEventCauseWire
+import com.gdelataillade.alarm.generated.AlarmEventVerbWire
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * The stored and wire forms of a host alarm event.
+ *
+ * Both matter beyond the obvious: the stored form is written to disk and has to
+ * stay readable by later plugin versions, and the wire form is what Dart decides
+ * behaviour from — a verb mapped to the wrong case would silently turn a
+ * deferral into a discard.
+ */
+class HostAlarmEventTest {
+    private val event = HostAlarmEvent(
+        alarmId = 42,
+        verb = AlarmEventVerb.MOVED,
+        cause = AlarmEventCause.PLATFORM_REFUSAL,
+        atMillis = 1_786_086_270_257,
+        recordedAtMillis = 1_786_086_270_589,
+    )
+
+    @Test
+    fun `toWire carries every field across`() {
+        val wire = event.toWire()
+
+        assertEquals(42L, wire.alarmId)
+        assertEquals(AlarmEventVerbWire.MOVED, wire.verb)
+        assertEquals(AlarmEventCauseWire.PLATFORM_REFUSAL, wire.cause)
+        assertEquals(1_786_086_270_257, wire.atMillis)
+        assertEquals(1_786_086_270_589, wire.recordedAtMillis)
+    }
+
+    @Test
+    fun `toWire maps every verb and cause to its own case`() {
+        // Guards against a mapping that compiles but collapses two cases into
+        // one, which Dart would read as the wrong thing having happened.
+        for (verb in AlarmEventVerb.entries) {
+            val mapped = event.copy(verb = verb).toWire().verb
+            assertEquals(verb.name, mapped.name)
+        }
+        for (cause in AlarmEventCause.entries) {
+            val mapped = event.copy(cause = cause).toWire().cause
+            assertEquals(cause.name, mapped.name)
+        }
+    }
+
+    @Test
+    fun `the stored form round trips`() {
+        val decoded = Json.decodeFromString<HostAlarmEvent>(Json.encodeToString(event))
+
+        assertEquals(event, decoded)
+    }
+
+    @Test
+    fun `the stored form is the one already on disk`() {
+        // Pinned deliberately: this exact JSON is what 5.10.0 wrote, and a
+        // rename of any field would leave markers written by it unreadable
+        // after an upgrade — losing a deferral or a missed-alarm notice.
+        val onDisk = """{"alarmId":42,"verb":"MOVED","cause":"PLATFORM_REFUSAL",""" +
+            """"atMillis":1786086270257,"recordedAtMillis":1786086270589}"""
+
+        assertEquals(event, Json.decodeFromString<HostAlarmEvent>(onDisk))
+    }
+}

--- a/android/src/test/kotlin/com/gdelataillade/alarm/services/AlarmStorageTest.kt
+++ b/android/src/test/kotlin/com/gdelataillade/alarm/services/AlarmStorageTest.kt
@@ -1,0 +1,240 @@
+package com.gdelataillade.alarm.services
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import com.gdelataillade.alarm.models.AlarmEventCause
+import com.gdelataillade.alarm.models.AlarmEventVerb
+import com.gdelataillade.alarm.models.HostAlarmEvent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * The host event marker rules.
+ *
+ * These were previously covered only by driving a phone: the upgrade migration
+ * needed installing one release over another, and the verb-aware clearing needed
+ * a boot. Every rule here is one whose failure is *silent* — the alarm ends up in
+ * the right state and the application is simply never told why — which is exactly
+ * the kind that survives manual testing.
+ */
+class AlarmStorageTest {
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    private lateinit var storage: AlarmStorage
+    private lateinit var dataStore: DataStore<Preferences>
+
+    private val day = 24L * 60 * 60 * 1000
+
+    @Before
+    fun setUp() {
+        dataStore = PreferenceDataStoreFactory.create(
+            scope = CoroutineScope(Dispatchers.IO + SupervisorJob()),
+        ) { tempFolder.newFile("alarm-test-${System.nanoTime()}.preferences_pb") }
+        storage = AlarmStorage(dataStore)
+    }
+
+    private fun movedEvent(id: Int, at: Long, recordedAt: Long = at) = HostAlarmEvent(
+        alarmId = id,
+        verb = AlarmEventVerb.MOVED,
+        cause = AlarmEventCause.SNOOZE,
+        atMillis = at,
+        recordedAtMillis = recordedAt,
+    )
+
+    private fun droppedEvent(id: Int, at: Long, recordedAt: Long = at) = HostAlarmEvent(
+        alarmId = id,
+        verb = AlarmEventVerb.DROPPED,
+        cause = AlarmEventCause.STALE_AT_BOOT,
+        atMillis = at,
+        recordedAtMillis = recordedAt,
+    )
+
+    /** Writes a marker in the snooze-only format 5.7.0 through 5.9.0 used. */
+    private fun writeLegacySnoozeMarker(id: Int, nextRingAtMillis: Long) = runBlocking {
+        dataStore.edit { prefs ->
+            prefs[stringPreferencesKey("__snoozed_alarm_id__$id")] =
+                nextRingAtMillis.toString()
+        }
+    }
+
+    private fun rawKeys(): Set<String> = runBlocking {
+        var keys = emptySet<String>()
+        dataStore.edit { prefs -> keys = prefs.asMap().keys.map { it.name }.toSet() }
+        keys
+    }
+
+    @Test
+    fun `a saved event is read back`() {
+        val event = movedEvent(42, System.currentTimeMillis() + 60_000)
+        storage.saveAlarmEvent(event)
+
+        assertEquals(listOf(event), storage.getPendingAlarmEvents())
+    }
+
+    @Test
+    fun `the newest event for an alarm wins`() {
+        // One marker per alarm, last write wins: if an alarm is deferred and then
+        // discarded, the terminal state is what the application needs.
+        val now = System.currentTimeMillis()
+        storage.saveAlarmEvent(movedEvent(42, now + 60_000))
+        storage.saveAlarmEvent(droppedEvent(42, now, recordedAt = now + 1))
+
+        val pending = storage.getPendingAlarmEvents()
+
+        assertEquals(1, pending.size)
+        assertEquals(AlarmEventVerb.DROPPED, pending.single().verb)
+    }
+
+    @Test
+    fun `unsaveAlarm clears a deferral but keeps a discard`() {
+        // The trap. A discard is recorded *by* removing the alarm, so clearing
+        // every marker here would delete the very event the application is
+        // waiting to be told about — and nothing would look wrong, because the
+        // alarm is correctly gone either way.
+        val now = System.currentTimeMillis()
+        storage.saveAlarmEvent(movedEvent(1, now + 60_000))
+        storage.saveAlarmEvent(droppedEvent(2, now))
+
+        storage.unsaveAlarm(1)
+        storage.unsaveAlarm(2)
+
+        val pending = storage.getPendingAlarmEvents()
+        assertEquals(1, pending.size)
+        assertEquals(2, pending.single().alarmId)
+        assertEquals(AlarmEventVerb.DROPPED, pending.single().verb)
+    }
+
+    @Test
+    fun `unsaveAlarm clears a legacy snooze marker`() {
+        writeLegacySnoozeMarker(7, System.currentTimeMillis() + 60_000)
+
+        storage.unsaveAlarm(7)
+
+        assertTrue(storage.getPendingAlarmEvents().isEmpty())
+    }
+
+    @Test
+    fun `a legacy snooze marker reads as a deferral`() {
+        // Written by 5.7.0 through 5.9.0. An upgrade must not lose a deferral
+        // that was pending when the app was replaced.
+        val nextRingAt = System.currentTimeMillis() + 60_000
+        writeLegacySnoozeMarker(7, nextRingAt)
+
+        val event = storage.getPendingAlarmEvents().single()
+
+        assertEquals(7, event.alarmId)
+        assertEquals(AlarmEventVerb.MOVED, event.verb)
+        assertEquals(AlarmEventCause.SNOOZE, event.cause)
+        assertEquals(nextRingAt, event.atMillis)
+        // Nothing recorded when it was written, so the ring time stands in --
+        // which is exactly what the old acknowledgement compared against.
+        assertEquals(nextRingAt, event.recordedAtMillis)
+    }
+
+    @Test
+    fun `acknowledging a legacy marker removes it`() {
+        val nextRingAt = System.currentTimeMillis() + 60_000
+        writeLegacySnoozeMarker(7, nextRingAt)
+
+        storage.acknowledgeAlarmEvent(7, nextRingAt)
+
+        assertTrue(storage.getPendingAlarmEvents().isEmpty())
+    }
+
+    @Test
+    fun `acknowledging matches on the recorded time`() {
+        val now = System.currentTimeMillis()
+        storage.saveAlarmEvent(movedEvent(42, now + 60_000, recordedAt = now))
+
+        storage.acknowledgeAlarmEvent(42, now)
+
+        assertTrue(storage.getPendingAlarmEvents().isEmpty())
+    }
+
+    @Test
+    fun `a late acknowledgement cannot discard a newer event`() {
+        // The guard that keeps a second deferral from being thrown away by the
+        // reply to the first one.
+        val now = System.currentTimeMillis()
+        storage.saveAlarmEvent(movedEvent(42, now + 60_000, recordedAt = now))
+        storage.saveAlarmEvent(movedEvent(42, now + 120_000, recordedAt = now + 500))
+
+        storage.acknowledgeAlarmEvent(42, now)
+
+        val pending = storage.getPendingAlarmEvents()
+        assertEquals(1, pending.size)
+        assertEquals(now + 500, pending.single().recordedAtMillis)
+    }
+
+    @Test
+    fun `a deferral survives longer than a discard`() {
+        // Per-verb TTL: the alarm behind a deferral is still owed, while a
+        // missed-alarm notice surfacing days later is only noise.
+        val now = System.currentTimeMillis()
+        storage.saveAlarmEvent(movedEvent(1, now - 3 * day))
+        storage.saveAlarmEvent(droppedEvent(2, now - 3 * day))
+
+        val pending = storage.getPendingAlarmEvents().associateBy { it.alarmId }
+
+        assertNotNull("a 3-day-old deferral is still applicable", pending[1])
+        assertNull("a 3-day-old discard is stale", pending[2])
+    }
+
+    @Test
+    fun `an ancient deferral is pruned`() {
+        storage.saveAlarmEvent(movedEvent(1, System.currentTimeMillis() - 8 * day))
+
+        assertTrue(storage.getPendingAlarmEvents().isEmpty())
+    }
+
+    @Test
+    fun `an expired marker is deleted rather than merely hidden`() {
+        // Otherwise a marker Dart can never apply accumulates forever.
+        storage.saveAlarmEvent(movedEvent(1, System.currentTimeMillis() - 8 * day))
+
+        storage.getPendingAlarmEvents()
+
+        assertTrue(rawKeys().none { it.startsWith("__alarm_event__") })
+    }
+
+    @Test
+    fun `an unreadable marker is dropped instead of failing the whole read`() {
+        // One corrupt row must not cost the application every other event.
+        val good = movedEvent(1, System.currentTimeMillis() + 60_000)
+        storage.saveAlarmEvent(good)
+        runBlocking {
+            dataStore.edit { prefs ->
+                prefs[stringPreferencesKey("__alarm_event__999")] = "not json"
+            }
+        }
+
+        assertEquals(listOf(good), storage.getPendingAlarmEvents())
+        assertTrue(rawKeys().none { it == "__alarm_event__999" })
+    }
+
+    @Test
+    fun `clearAlarmEvent removes both marker formats`() {
+        val now = System.currentTimeMillis()
+        storage.saveAlarmEvent(movedEvent(1, now + 60_000))
+        writeLegacySnoozeMarker(2, now + 60_000)
+
+        storage.clearAlarmEvent(1)
+        storage.clearAlarmEvent(2)
+
+        assertTrue(storage.getPendingAlarmEvents().isEmpty())
+    }
+}


### PR DESCRIPTION
## Why

The Android half of 5.9.0 and 5.10.0 was verified by me driving a Pixel 8a. Nothing in CI covers any of it. The Dart suite pins the Dart-visible contract and **passes with the Kotlin changes reverted**, so a regression in the host event markers would reach a release unnoticed.

This adds the missing source set and wires it into the `build-android` job, so it actually gates future changes.

## What is covered

`AlarmStorage` is where the silent failures live — the ones where the alarm ends up in the right state and the app is simply never told why. That shape survives manual testing, which is why it is the first thing worth pinning:

- **`unsaveAlarm` clears a `MOVED` marker but keeps a `DROPPED` one.** The trap: a discard is recorded *by* removing the alarm, so clearing every marker here would delete the event the app is waiting for — and nothing would look wrong, because the alarm is correctly gone either way.
- **Legacy `__snoozed_alarm_id__` markers still read as deferrals.** Written by 5.7.0–5.9.0; needed installing one release over another to check by hand.
- **An acknowledgement matches on `recordedAt`,** so the reply to a first deferral cannot discard a second one.
- Per-verb TTLs, expiry *deleting* rather than hiding, and one corrupt row not costing the whole read.
- **The stored JSON is pinned to exactly what 5.10.0 writes,** so renaming a field can't silently orphan markers across an upgrade.

## Why no Robolectric

These are plain JVM tests, and they run in about a second:

- `testOptions.unitTests.returnDefaultValues = true` makes `io.flutter.Log` → `android.util.Log` calls no-ops instead of throwing "not mocked".
- DataStore runs over a `TemporaryFolder` file via `PreferenceDataStoreFactory.create`, so no `Context` is needed.

`AlarmStorage` gained an `internal constructor(dataStore)` with the `Context` one delegating to it. Production call sites are unchanged.

Robolectric/mockk would be needed to reach `AlarmScheduler`, `AlarmService` and `SnoozeCoordinator`, which are still uncovered — deliberately left for a follow-up rather than half-done here.

## The second commit: a green run wasn't proof the tests ran

While checking the first commit I deleted the test sources and **the build still passed** — a test task with no sources is `NO-SOURCE`, which Gradle treats as success. So `gradlew :alarm:test` exiting 0 could not distinguish "17 tests green" from "the source set silently stopped being picked up", which is exactly the regression this PR exists to prevent (an AGP upgrade, a moved directory).

Two complementary checks now:

- the test task logs its counts and **fails on zero tests** — covers "the task ran but matched nothing"
- CI reads the JUnit XML and requires a non-zero total — covers the task being **skipped outright**. Sound because the checkout is clean, so no earlier run's results can stand in for this one's.

## Verification

Every test was checked by reverting the code it guards and confirming **that test alone** fails:

| Reverted | Failing test |
|---|---|
| `unsaveAlarm` clears every marker | `unsaveAlarm clears a deferral but keeps a discard` |
| legacy read path removed | `a legacy snooze marker reads as a deferral` |
| `recordedAt` match dropped | `a late acknowledgement cannot discard a newer event` |

The zero-test guard was checked the same way, by extracting the step's script straight out of the workflow and running it against each case:

| Case | Result |
|---|---|
| no results at all (task skipped) | exit 1 |
| results present but reporting zero tests | exit 1 |
| the real results | `2 suites, 17 tests`, exit 0 |

Counts read from the JUnit XML rather than trusting "BUILD SUCCESSFUL". From the CI run itself:

```
testDebugUnitTest: 17 tests, 0 failed, 0 skipped
2 suites, 17 tests
```

Also `flutter analyze` clean, 89 Dart tests passing, and the full CI sequence replayed locally from a clean Gradle state (`./gradlew clean :alarm:test`).

No library code behaviour changes, so no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)