### PR TITLE
feat(android): discard alarms that went stale while the device was off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.11.0
+* **[Android] An alarm whose time passed while the device was off is now discarded at boot instead of ringing immediately (#418).** Previously every stored alarm was re-armed with no age limit, so an alarm set for 06:00 sounded at 08:00 when the phone was switched on. Alarms missed by more than `AlarmSettings.androidStaleAfter` are dropped and reported through `Alarm.events` as an `AlarmDropped` with cause `staleAtBoot`, so the application can tell its user the alarm was missed.
+* Added `AlarmSettings.androidStaleAfter`, defaulting to 15 minutes — long enough that a reboot straddling the alarm still rings, short enough that a phone switched on hours later stays quiet. Pass `null` to never discard, which is the behavior of 5.10.0 and earlier.
+
 ## 5.10.0
 * [Android] Fixed an alarm due within ~45s of a reboot never ringing (#424).
 * Added `Alarm.events`, reporting deferrals and discards the host made on its own.

--- a/android/src/main/kotlin/com/gdelataillade/alarm/alarm/BootReceiver.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/alarm/BootReceiver.kt
@@ -4,12 +4,57 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.util.Log
+import com.gdelataillade.alarm.models.AlarmEventCause
+import com.gdelataillade.alarm.models.AlarmEventVerb
+import com.gdelataillade.alarm.models.AlarmSettings
+import com.gdelataillade.alarm.models.HostAlarmEvent
 import com.gdelataillade.alarm.services.AlarmStorage
 import com.gdelataillade.alarm.api.AlarmApiImpl
 
 class BootReceiver : BroadcastReceiver() {
     companion object {
         private const val TAG = "BootReceiver"
+
+        /**
+         * Whether [alarm] was due so long before [now] that ringing it would be
+         * noise rather than a wake-up.
+         *
+         * A null `androidStaleAfterMillis` never goes stale, which is what an
+         * application asks for when the alarm has to ring however late.
+         */
+        internal fun isStale(alarm: AlarmSettings, now: Long): Boolean {
+            val staleAfterMillis = alarm.androidStaleAfterMillis ?: return false
+            return now - alarm.dateTime.time > staleAfterMillis
+        }
+
+        /**
+         * Discards [alarm] and records why, instead of sounding it hours late.
+         *
+         * Nothing is reported to Dart from here: no Flutter engine is running at
+         * boot, which is the whole reason these decisions are recorded durably.
+         * The marker is drained on the next `Alarm.init()`.
+         */
+        internal fun discardStaleAlarm(alarm: AlarmSettings, storage: AlarmStorage, now: Long) {
+            val event = HostAlarmEvent(
+                alarmId = alarm.id,
+                verb = AlarmEventVerb.DROPPED,
+                cause = AlarmEventCause.STALE_AT_BOOT,
+                atMillis = alarm.dateTime.time,
+                recordedAtMillis = now,
+            )
+
+            // Same order AlarmService uses when it drops a refused ring:
+            // unsaveAlarm deliberately keeps DROPPED markers, so the record
+            // outlives the alarm it describes.
+            storage.saveAlarmEvent(event)
+            storage.unsaveAlarm(alarm.id)
+
+            Log.i(
+                TAG,
+                "Alarm ${alarm.id} was due at ${alarm.dateTime} and is past its stale " +
+                    "window; discarded instead of ringing at boot."
+            )
+        }
     }
 
     override fun onReceive(context: Context, intent: Intent) {
@@ -23,11 +68,19 @@ class BootReceiver : BroadcastReceiver() {
     private fun rescheduleAlarms(context: Context) {
         val alarmStorage = AlarmStorage(context)
         val storedAlarms = alarmStorage.getSavedAlarms()
+        // One reading for the whole batch, so alarms due at the same time are
+        // not judged differently because the loop took a moment.
+        val now = System.currentTimeMillis()
 
         Log.i(TAG, "Rescheduling ${storedAlarms.size} alarms")
 
         for (alarm in storedAlarms) {
             try {
+                if (isStale(alarm, now)) {
+                    discardStaleAlarm(alarm, alarmStorage, now)
+                    continue
+                }
+
                 Log.d(TAG, "Rescheduling alarm with ID: ${alarm.id}")
                 Log.d(TAG, "Alarm details: $alarm")
 

--- a/android/src/main/kotlin/com/gdelataillade/alarm/generated/FlutterBindings.g.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/generated/FlutterBindings.g.kt
@@ -176,7 +176,16 @@ data class AlarmSettingsWire (
    * below a few seconds, which survives neither process death nor
    * cancellation. Android only.
    */
-  val androidSnoozeDurationMillis: Long? = null
+  val androidSnoozeDurationMillis: Long? = null,
+  /**
+   * How long past its due time an alarm found at boot is still worth
+   * ringing, in milliseconds.
+   *
+   * Null means never discard. Absent from an alarm stored before the
+   * setting existed, which reads as the default rather than as null.
+   * Android only.
+   */
+  val androidStaleAfterMillis: Long? = null
 )
  {
   companion object {
@@ -196,7 +205,8 @@ data class AlarmSettingsWire (
       val androidStopAlarmOnTermination = pigeonVar_list[12] as Boolean
       val preferConnectedAudioDevice = pigeonVar_list[13] as Boolean
       val androidSnoozeDurationMillis = pigeonVar_list[14] as Long?
-      return AlarmSettingsWire(id, millisecondsSinceEpoch, assetAudioPath, volumeSettings, notificationSettings, loopAudio, vibrate, warningNotificationOnKill, androidFullScreenIntent, allowAlarmOverlap, allowSameSecondScheduling, iOSBackgroundAudio, androidStopAlarmOnTermination, preferConnectedAudioDevice, androidSnoozeDurationMillis)
+      val androidStaleAfterMillis = pigeonVar_list[15] as Long?
+      return AlarmSettingsWire(id, millisecondsSinceEpoch, assetAudioPath, volumeSettings, notificationSettings, loopAudio, vibrate, warningNotificationOnKill, androidFullScreenIntent, allowAlarmOverlap, allowSameSecondScheduling, iOSBackgroundAudio, androidStopAlarmOnTermination, preferConnectedAudioDevice, androidSnoozeDurationMillis, androidStaleAfterMillis)
     }
   }
   fun toList(): List<Any?> {
@@ -216,6 +226,7 @@ data class AlarmSettingsWire (
       androidStopAlarmOnTermination,
       preferConnectedAudioDevice,
       androidSnoozeDurationMillis,
+      androidStaleAfterMillis,
     )
   }
   override fun equals(other: Any?): Boolean {

--- a/android/src/main/kotlin/com/gdelataillade/alarm/models/AlarmSettings.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/models/AlarmSettings.kt
@@ -32,6 +32,8 @@ data class AlarmSettings(
     val preferConnectedAudioDevice: Boolean = false, // Defaults to false for backward compatibility
     // Null, or below SNOOZE_MINIMUM_MILLIS, offers no snooze.
     val androidSnoozeDurationMillis: Long? = null,
+    // Absent means the default; an explicit null means never discard.
+    val androidStaleAfterMillis: Long? = DEFAULT_STALE_AFTER_MILLIS,
 ) {
     /** Whether this alarm can be deferred rather than only stopped. */
     val canSnooze: Boolean
@@ -47,6 +49,16 @@ data class AlarmSettings(
          * than this could not be honoured or undone.
          */
         const val SNOOZE_MINIMUM_MILLIS = 60_000L
+
+        /**
+         * How long past its due time an alarm found at boot is still worth
+         * ringing, when the alarm does not say.
+         *
+         * Long enough that a reboot straddling the alarm still rings, short
+         * enough that a phone switched on hours later stays quiet. Must match
+         * `AlarmSettings.defaultStaleAfter` on the Dart side.
+         */
+        const val DEFAULT_STALE_AFTER_MILLIS = 900_000L
 
         fun fromWire(e: AlarmSettingsWire): AlarmSettings {
             return AlarmSettings(
@@ -64,6 +76,7 @@ data class AlarmSettings(
                 e.androidStopAlarmOnTermination,
                 e.preferConnectedAudioDevice,
                 e.androidSnoozeDurationMillis,
+                e.androidStaleAfterMillis,
             )
         }
 
@@ -102,6 +115,17 @@ data class AlarmSettings(
             // the alarm can only be stopped.
             val androidSnoozeDurationMillis = jsonObject.primitiveLong("androidSnoozeDurationMillis")
 
+            // Three states, which primitiveLong alone cannot tell apart: absent
+            // means an alarm saved before the cutoff existed, and takes the
+            // default; an explicit null means never discard; anything
+            // unparseable falls back to the default rather than dropping the
+            // alarm, matching the Dart reader.
+            val androidStaleAfterMillis = when (val stale = jsonObject["androidStaleAfterMillis"]) {
+                null -> DEFAULT_STALE_AFTER_MILLIS
+                JsonNull -> null
+                else -> stale.jsonPrimitive.content.toLongOrNull() ?: DEFAULT_STALE_AFTER_MILLIS
+            }
+
             // Handle backward compatibility for `volumeSettings`
             val volumeSettings = jsonObject["volumeSettings"]?.let {
                 Json.decodeFromJsonElement(VolumeSettings.serializer(), it)
@@ -135,6 +159,7 @@ data class AlarmSettings(
                 androidStopAlarmOnTermination = androidStopAlarmOnTermination,
                 preferConnectedAudioDevice = preferConnectedAudioDevice,
                 androidSnoozeDurationMillis = androidSnoozeDurationMillis,
+                androidStaleAfterMillis = androidStaleAfterMillis,
             )
         }
     }

--- a/android/src/main/kotlin/com/gdelataillade/alarm/services/AlarmStorage.kt
+++ b/android/src/main/kotlin/com/gdelataillade/alarm/services/AlarmStorage.kt
@@ -155,9 +155,12 @@ class AlarmStorage internal constructor(private val dataStore: DataStore<Prefere
      *
      * Non-destructive on purpose: a marker survives until
      * [acknowledgeAlarmEvent] confirms Dart durably applied it, so a read
-     * followed by a crash loses nothing. Markers whose moment has passed by more
-     * than the per-verb TTL are dropped, so one Dart can never apply cannot
-     * accumulate forever.
+     * followed by a crash loses nothing. Markers are dropped once the per-verb
+     * TTL has passed, so one Dart can never apply cannot accumulate forever.
+     * That is measured from the later of when the event happened and when it
+     * was recorded: a deferral ages from the time it now rings, while a discard
+     * of an alarm missed days ago ages from the moment it was discarded rather
+     * than from a due time that was already long gone.
      *
      * Also reads markers written by 5.7.0–5.9.0 under the old snooze-only key,
      * so an app upgrading with a deferral pending does not lose it. Those carry
@@ -189,8 +192,14 @@ class AlarmStorage internal constructor(private val dataStore: DataStore<Prefere
                     AlarmEventVerb.MOVED -> MOVED_MARKER_TTL_MILLIS
                     AlarmEventVerb.DROPPED -> DROPPED_MARKER_TTL_MILLIS
                 }
-                if (now - event.atMillis > ttl) {
-                    Log.w(TAG, "Dropping ${event.verb} marker for ${event.alarmId}, stale since ${event.atMillis}.")
+                // The later of the two, not atMillis alone: a STALE_AT_BOOT
+                // drop describes an alarm whose own time may be days past, so
+                // ageing it by that would expire the marker before the
+                // application ever ran. A MOVED marker still ages from the time
+                // it now rings, which is the later value for a deferral.
+                val bornAt = maxOf(event.atMillis, event.recordedAtMillis)
+                if (now - bornAt > ttl) {
+                    Log.w(TAG, "Dropping ${event.verb} marker for ${event.alarmId}, stale since $bornAt.")
                     expired.add(key)
                 } else {
                     events.add(event)

--- a/android/src/test/kotlin/com/gdelataillade/alarm/alarm/BootReceiverTest.kt
+++ b/android/src/test/kotlin/com/gdelataillade/alarm/alarm/BootReceiverTest.kt
@@ -1,0 +1,157 @@
+package com.gdelataillade.alarm.alarm
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import com.gdelataillade.alarm.models.AlarmEventCause
+import com.gdelataillade.alarm.models.AlarmEventVerb
+import com.gdelataillade.alarm.models.AlarmSettings
+import com.gdelataillade.alarm.models.NotificationSettings
+import com.gdelataillade.alarm.models.VolumeSettings
+import com.gdelataillade.alarm.services.AlarmStorage
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.util.Date
+
+/**
+ * What boot does with an alarm whose time passed while the device was off.
+ *
+ * Re-arming it unconditionally is what 5.10.0 did, and it means an alarm set
+ * for 06:00 blares at 08:00 when the phone is switched on — telling the user
+ * nothing they cannot already see, having failed at the one job it had. The
+ * decision is taken where no Flutter engine is running, so the only way the
+ * application ever learns of it is the durable marker left behind.
+ */
+class BootReceiverTest {
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    private lateinit var storage: AlarmStorage
+    private lateinit var dataStore: DataStore<Preferences>
+
+    private val minute = 60_000L
+
+    /**
+     * Derived from the clock, not a fixed instant.
+     *
+     * A dropped marker older than a day is pruned on read, so a hard-coded
+     * epoch would pass until the day it silently stopped exercising
+     * anything.
+     */
+    private val dueAt = System.currentTimeMillis() - 3 * 60 * minute
+
+    @Before
+    fun setUp() {
+        dataStore = PreferenceDataStoreFactory.create(
+            scope = CoroutineScope(Dispatchers.IO + SupervisorJob()),
+        ) { tempFolder.newFile("boot-test-${System.nanoTime()}.preferences_pb") }
+        storage = AlarmStorage(dataStore)
+    }
+
+    private fun alarm(
+        id: Int = 42,
+        dueAtMillis: Long = dueAt,
+        staleAfterMillis: Long? = AlarmSettings.DEFAULT_STALE_AFTER_MILLIS,
+    ) = AlarmSettings(
+        id = id,
+        dateTime = Date(dueAtMillis),
+        assetAudioPath = "assets/alarm.mp3",
+        volumeSettings = VolumeSettings(
+            volume = null,
+            fadeDuration = null,
+            fadeSteps = emptyList(),
+            volumeEnforced = false,
+        ),
+        notificationSettings = NotificationSettings(title = "Title", body = "Body"),
+        loopAudio = true,
+        vibrate = true,
+        warningNotificationOnKill = true,
+        androidFullScreenIntent = true,
+        androidStaleAfterMillis = staleAfterMillis,
+    )
+
+    @Test
+    fun `an alarm still ahead of now is not stale`() {
+        assertFalse(BootReceiver.isStale(alarm(), dueAt - 60 * minute))
+    }
+
+    @Test
+    fun `an alarm inside its window is not stale`() {
+        // The reboot case the window exists for: the phone restarted itself for
+        // a system update at 05:58 and was back at 06:02, so the alarm is late
+        // but still worth ringing.
+        assertFalse(BootReceiver.isStale(alarm(), dueAt + 2 * minute))
+        // Exactly at the boundary still rings; the window is how long it stays
+        // worth ringing, not the first instant it stops.
+        assertFalse(BootReceiver.isStale(alarm(), dueAt + 15 * minute))
+    }
+
+    @Test
+    fun `an alarm past its window is stale`() {
+        assertTrue(BootReceiver.isStale(alarm(), dueAt + 15 * minute + 1))
+        assertTrue(BootReceiver.isStale(alarm(), dueAt + 120 * minute))
+    }
+
+    @Test
+    fun `an alarm that never discards is never stale`() {
+        // The escape hatch for an alarm that has to ring however late, and the
+        // behaviour of 5.10.0 and earlier for every alarm.
+        val never = alarm(staleAfterMillis = null)
+
+        assertFalse(BootReceiver.isStale(never, dueAt + 365 * 24 * 60 * minute))
+    }
+
+    @Test
+    fun `a longer window set by the alarm is honoured`() {
+        val patient = alarm(staleAfterMillis = 4 * 60 * minute)
+
+        assertFalse(BootReceiver.isStale(patient, dueAt + 3 * 60 * minute))
+        assertTrue(BootReceiver.isStale(patient, dueAt + 5 * 60 * minute))
+    }
+
+    @Test
+    fun `a marker for an alarm missed by more than a day still reaches Dart`() {
+        // The case the cutoff exists for most: the phone was off for days, so
+        // the alarm's own time is long past. Expiring the marker by that time
+        // rather than by when it was recorded would delete it before the app
+        // ever opened, and the drop the application is promised would be the
+        // one thing it never hears about.
+        val longMissed = alarm(dueAtMillis = System.currentTimeMillis() - 3 * 24 * 60 * minute)
+
+        BootReceiver.discardStaleAlarm(longMissed, storage, System.currentTimeMillis())
+
+        assertEquals(1, storage.getPendingAlarmEvents().size)
+    }
+
+    @Test
+    fun `discarding removes the alarm and leaves a marker saying why`() {
+        val stale = alarm()
+        storage.saveAlarm(stale)
+        val now = dueAt + 120 * minute
+
+        BootReceiver.discardStaleAlarm(stale, storage, now)
+
+        // The alarm is gone — nothing will ring — and the only remaining trace
+        // is what the application reads on its next init.
+        assertEquals(emptyList<AlarmSettings>(), storage.getSavedAlarms())
+
+        val events = storage.getPendingAlarmEvents()
+        assertEquals(1, events.size)
+        val event = events.single()
+        assertEquals(stale.id, event.alarmId)
+        assertEquals(AlarmEventVerb.DROPPED, event.verb)
+        assertEquals(AlarmEventCause.STALE_AT_BOOT, event.cause)
+        // The time it should have rung, not the time it was thrown away, so the
+        // application can tell the user which alarm was missed.
+        assertEquals(dueAt, event.atMillis)
+        assertEquals(now, event.recordedAtMillis)
+    }
+}

--- a/android/src/test/kotlin/com/gdelataillade/alarm/models/AlarmSettingsTest.kt
+++ b/android/src/test/kotlin/com/gdelataillade/alarm/models/AlarmSettingsTest.kt
@@ -1,0 +1,109 @@
+package com.gdelataillade.alarm.models
+
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Test
+import java.util.Date
+
+/**
+ * How `androidStaleAfterMillis` survives storage.
+ *
+ * Three states have to stay apart across a restart, and only two of them are
+ * obvious. Absent means an alarm saved before the cutoff existed, which has to
+ * take the default so an upgrade actually changes what those alarms do at boot.
+ * An explicit null means never discard. Collapsing the two either strands
+ * legacy alarms on the old policy or silently discards an alarm the application
+ * said must always ring.
+ */
+class AlarmSettingsTest {
+    private val defaultMillis = AlarmSettings.DEFAULT_STALE_AFTER_MILLIS
+
+    private fun settings(staleAfterMillis: Long? = defaultMillis) = AlarmSettings(
+        id = 42,
+        dateTime = Date(1_786_086_270_000),
+        assetAudioPath = "assets/alarm.mp3",
+        volumeSettings = VolumeSettings(
+            volume = 0.8,
+            fadeDuration = null,
+            fadeSteps = emptyList(),
+            volumeEnforced = false,
+        ),
+        notificationSettings = NotificationSettings(title = "Title", body = "Body"),
+        loopAudio = true,
+        vibrate = true,
+        warningNotificationOnKill = true,
+        androidFullScreenIntent = true,
+        androidStaleAfterMillis = staleAfterMillis,
+    )
+
+    @Test
+    fun `defaults to fifteen minutes`() {
+        assertEquals(900_000L, defaultMillis)
+        assertEquals(defaultMillis, settings().androidStaleAfterMillis)
+    }
+
+    @Test
+    fun `an explicit null round trips as never discard`() {
+        val json = Json.encodeToString(settings(staleAfterMillis = null))
+
+        assertNull(Json.decodeFromString<AlarmSettings>(json).androidStaleAfterMillis)
+    }
+
+    @Test
+    fun `a duration round trips`() {
+        val json = Json.encodeToString(settings(staleAfterMillis = 2_400_000L))
+
+        assertEquals(
+            2_400_000L,
+            Json.decodeFromString<AlarmSettings>(json).androidStaleAfterMillis,
+        )
+    }
+
+    @Test
+    fun `an alarm stored before the cutoff existed takes the default`() {
+        // Json omits a property equal to its declared default, so an alarm using
+        // the default is stored exactly like one written by 5.10.0: no key at
+        // all. Both therefore have to read back as the default, not as null.
+        val json = Json.encodeToString(settings())
+
+        assertFalse(json.contains("androidStaleAfterMillis"))
+        assertEquals(
+            defaultMillis,
+            Json.decodeFromString<AlarmSettings>(json).androidStaleAfterMillis,
+        )
+    }
+
+    @Test
+    fun `the legacy parser keeps the three states apart`() {
+        val full = Json.encodeToString(settings(staleAfterMillis = 2_400_000L))
+
+        assertEquals(
+            2_400_000L,
+            AlarmSettings.fromJson(full).androidStaleAfterMillis,
+        )
+        assertNull(
+            AlarmSettings.fromJson(
+                full.replace("\"androidStaleAfterMillis\":2400000", "\"androidStaleAfterMillis\":null")
+            ).androidStaleAfterMillis,
+        )
+        assertEquals(
+            defaultMillis,
+            AlarmSettings.fromJson(
+                full.replace(",\"androidStaleAfterMillis\":2400000", "")
+            ).androidStaleAfterMillis,
+        )
+    }
+
+    @Test
+    fun `the legacy parser falls back to the default on an unusable value`() {
+        // Recovering matches the Dart reader: the alarm itself is still good,
+        // and refusing to parse it would lose the alarm over one bad field.
+        val json = Json.encodeToString(settings(staleAfterMillis = 2_400_000L))
+            .replace("\"androidStaleAfterMillis\":2400000", "\"androidStaleAfterMillis\":\"oops\"")
+
+        assertEquals(defaultMillis, AlarmSettings.fromJson(json).androidStaleAfterMillis)
+    }
+}

--- a/android/src/test/kotlin/com/gdelataillade/alarm/services/AlarmStorageTest.kt
+++ b/android/src/test/kotlin/com/gdelataillade/alarm/services/AlarmStorageTest.kt
@@ -195,6 +195,27 @@ class AlarmStorageTest {
     }
 
     @Test
+    fun `a discard recorded now survives an alarm that was due days ago`() {
+        // The TTL is how long a notice stays worth delivering, not how old the
+        // alarm was. A discard at boot always describes a due time that has
+        // passed — that is what made it stale — so ageing it by that time would
+        // expire the marker the moment it was written.
+        val now = System.currentTimeMillis()
+        storage.saveAlarmEvent(droppedEvent(2, now - 3 * day, recordedAt = now))
+
+        assertNotNull(storage.getPendingAlarmEvents().firstOrNull { it.alarmId == 2 })
+    }
+
+    @Test
+    fun `a discard recorded more than a day ago is still pruned`() {
+        // The TTL still has to bite, or a marker Dart never applies lives forever.
+        val now = System.currentTimeMillis()
+        storage.saveAlarmEvent(droppedEvent(2, now - 3 * day, recordedAt = now - 2 * day))
+
+        assertTrue(storage.getPendingAlarmEvents().isEmpty())
+    }
+
+    @Test
     fun `an ancient deferral is pruned`() {
         storage.saveAlarmEvent(movedEvent(1, System.currentTimeMillis() - 8 * day))
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "5.10.0"
+    version: "5.11.0"
   args:
     dependency: transitive
     description:

--- a/ios/alarm/Sources/alarm/generated/FlutterBindings.g.swift
+++ b/ios/alarm/Sources/alarm/generated/FlutterBindings.g.swift
@@ -200,6 +200,13 @@ struct AlarmSettingsWire: Hashable {
   /// below a few seconds, which survives neither process death nor
   /// cancellation. Android only.
   var androidSnoozeDurationMillis: Int64? = nil
+  /// How long past its due time an alarm found at boot is still worth
+  /// ringing, in milliseconds.
+  ///
+  /// Null means never discard. Absent from an alarm stored before the
+  /// setting existed, which reads as the default rather than as null.
+  /// Android only.
+  var androidStaleAfterMillis: Int64? = nil
 
 
   // swift-format-ignore: AlwaysUseLowerCamelCase
@@ -219,6 +226,7 @@ struct AlarmSettingsWire: Hashable {
     let androidStopAlarmOnTermination = pigeonVar_list[12] as! Bool
     let preferConnectedAudioDevice = pigeonVar_list[13] as! Bool
     let androidSnoozeDurationMillis: Int64? = nilOrValue(pigeonVar_list[14])
+    let androidStaleAfterMillis: Int64? = nilOrValue(pigeonVar_list[15])
 
     return AlarmSettingsWire(
       id: id,
@@ -235,7 +243,8 @@ struct AlarmSettingsWire: Hashable {
       iOSBackgroundAudio: iOSBackgroundAudio,
       androidStopAlarmOnTermination: androidStopAlarmOnTermination,
       preferConnectedAudioDevice: preferConnectedAudioDevice,
-      androidSnoozeDurationMillis: androidSnoozeDurationMillis
+      androidSnoozeDurationMillis: androidSnoozeDurationMillis,
+      androidStaleAfterMillis: androidStaleAfterMillis
     )
   }
   func toList() -> [Any?] {
@@ -255,6 +264,7 @@ struct AlarmSettingsWire: Hashable {
       androidStopAlarmOnTermination,
       preferConnectedAudioDevice,
       androidSnoozeDurationMillis,
+      androidStaleAfterMillis,
     ]
   }
   static func == (lhs: AlarmSettingsWire, rhs: AlarmSettingsWire) -> Bool {

--- a/lib/alarm.dart
+++ b/lib/alarm.dart
@@ -349,6 +349,17 @@ class Alarm {
       );
     }
 
+    final staleAfter = alarmSettings.androidStaleAfter;
+    if (staleAfter != null && staleAfter < _ringStartGrace) {
+      throw AlarmException(
+        AlarmErrorCode.invalidArguments,
+        message: 'androidStaleAfter cannot be shorter than the '
+            '$_ringStartGrace grace [checkAlarm] gives an alarm that is due '
+            'but not yet ringing, or Dart would spare an alarm the boot '
+            'path had already discarded. Provided: $staleAfter',
+      );
+    }
+
     // Everything below only warns. These settings are inert on iOS, and
     // NotificationSettings is shared across platforms, so throwing would break
     // apps that configure a snooze label once for both.

--- a/lib/model/alarm_settings.dart
+++ b/lib/model/alarm_settings.dart
@@ -6,6 +6,13 @@ import 'package:logging/logging.dart';
 
 part 'alarm_settings.g.dart';
 
+/// Backs [AlarmSettings.defaultStaleAfter].
+///
+/// Top level because `json_serializable` copies a constructor default into
+/// the generated part verbatim, where a static member of the class is not in
+/// scope. [AlarmSettings.defaultStaleAfter] is the name to use.
+const _defaultStaleAfter = Duration(minutes: 15);
+
 /// [AlarmSettings] is a model that contains all the settings to customize
 /// and set an alarm.
 @JsonSerializable()
@@ -28,6 +35,7 @@ class AlarmSettings extends Equatable {
     this.preferConnectedAudioDevice = false,
     this.payload,
     this.androidSnoozeDuration,
+    this.androidStaleAfter = _defaultStaleAfter,
   });
 
   /// Constructs an `AlarmSettings` instance from the given JSON data.
@@ -100,6 +108,23 @@ class AlarmSettings extends Equatable {
   /// cancellation — so a shorter snooze could be neither guaranteed nor undone.
   /// A shorter duration offers no snooze at all rather than an unreliable one.
   static const minSnoozeDuration = Duration(minutes: 1);
+
+  /// Default [androidStaleAfter].
+  ///
+  /// Long enough that a reboot straddling the alarm still rings — a phone
+  /// that restarts itself at 05:58 for a system update is back well inside
+  /// this — and short enough that a phone switched on hours later stays
+  /// quiet, where the user is already awake and a late ring is noise.
+  static const defaultStaleAfter = _defaultStaleAfter;
+
+  /// Value [androidStaleAfter] takes in JSON to mean never discard.
+  ///
+  /// A null field is omitted from the encoded map entirely, and a missing
+  /// key has to keep meaning [defaultStaleAfter] so that alarms stored
+  /// before this setting existed still get the new policy. Writing a
+  /// sentinel instead keeps the two distinguishable across a restart. Part
+  /// of the contract of [toJson], which is public.
+  static const neverDiscardSentinel = -1;
 
   /// Unique identifier associated with the alarm. Cannot be 0 or -1.
   final int id;
@@ -232,6 +257,55 @@ class AlarmSettings extends Equatable {
   /// delays, and the fallback survives neither process death nor cancellation.
   final Duration? androidSnoozeDuration;
 
+  /// How long past its due time an alarm found at boot is still worth
+  /// ringing.
+  ///
+  /// **Android only.** A device that was off when an alarm was due rings it
+  /// as soon as it boots. Past this much delay that is noise rather than a
+  /// wake-up — an alarm set for 06:00 blaring at 08:00 tells the user
+  /// nothing they cannot already see — so the alarm is discarded instead
+  /// and reported as an [AlarmDropped] with cause
+  /// [AlarmEventCause.staleAtBoot].
+  ///
+  /// Defaults to [defaultStaleAfter]. **An explicit null never discards**,
+  /// which is the behaviour of 5.10.0 and earlier, for an alarm that has to
+  /// ring however late. Omitting it and asking for null are deliberately
+  /// different things.
+  ///
+  /// Cannot be shorter than the grace period [Alarm.checkAlarm] already
+  /// gives an alarm that is due but not yet audible, or Dart would spare an
+  /// alarm the boot path had discarded; [Alarm.set] throws
+  /// [AlarmErrorCode.invalidArguments] instead of letting the two disagree.
+  @JsonKey(fromJson: _staleAfterFromJson, toJson: _staleAfterToJson)
+  final Duration? androidStaleAfter;
+
+  /// Reads [androidStaleAfter], recovering rather than throwing.
+  ///
+  /// Nothing between [Alarm.init] and the storage read catches, so throwing
+  /// here would cost the user every stored alarm rather than the one malformed
+  /// field. An unusable value falls back to [defaultStaleAfter], the same
+  /// answer an absent key gives.
+  static Duration? _staleAfterFromJson(Object? value) {
+    // Integral doubles are accepted: a re-encoder can turn 900000 into
+    // 900000.0, while 1.5 would truncate to a one-microsecond window.
+    if (value is! num || !value.isFinite || value % 1 != 0) {
+      _log.warning('Unusable androidStaleAfter $value; using the default.');
+      return defaultStaleAfter;
+    }
+    final micros = value.toInt();
+    if (micros == neverDiscardSentinel) return null;
+    if (micros < 0) {
+      _log.warning('Unusable androidStaleAfter $micros; using the default.');
+      return defaultStaleAfter;
+    }
+    return Duration(microseconds: micros);
+  }
+
+  /// Writes [androidStaleAfter]. The non-null return also stops
+  /// `json_serializable` omitting the key, which is what would lose a null.
+  static int _staleAfterToJson(Duration? value) =>
+      value?.inMicroseconds ?? neverDiscardSentinel;
+
   /// Converts the `AlarmSettings` instance to a JSON object.
   Map<String, dynamic> toJson() => _$AlarmSettingsToJson(this);
 
@@ -252,6 +326,7 @@ class AlarmSettings extends Equatable {
         androidStopAlarmOnTermination: androidStopAlarmOnTermination,
         preferConnectedAudioDevice: preferConnectedAudioDevice,
         androidSnoozeDurationMillis: androidSnoozeDuration?.inMilliseconds,
+        androidStaleAfterMillis: androidStaleAfter?.inMilliseconds,
       );
 
   /// Creates a copy of `AlarmSettings` but with the given fields replaced with
@@ -287,6 +362,7 @@ class AlarmSettings extends Equatable {
     bool? preferConnectedAudioDevice,
     String? Function()? payload,
     Duration? Function()? androidSnoozeDuration,
+    Duration? Function()? androidStaleAfter,
   }) {
     return AlarmSettings(
       id: id ?? this.id,
@@ -316,6 +392,11 @@ class AlarmSettings extends Equatable {
       androidSnoozeDuration: androidSnoozeDuration != null
           ? androidSnoozeDuration()
           : this.androidSnoozeDuration,
+      // Wrapped for the same reason, and here null is a real choice rather
+      // than an absence: it means never discard.
+      androidStaleAfter: androidStaleAfter != null
+          ? androidStaleAfter()
+          : this.androidStaleAfter,
     );
   }
 
@@ -337,5 +418,6 @@ class AlarmSettings extends Equatable {
         preferConnectedAudioDevice,
         payload,
         androidSnoozeDuration,
+        androidStaleAfter,
       ];
 }

--- a/lib/model/alarm_settings.g.dart
+++ b/lib/model/alarm_settings.g.dart
@@ -43,6 +43,11 @@ AlarmSettings _$AlarmSettingsFromJson(Map<String, dynamic> json) =>
               (v) => v == null
                   ? null
                   : Duration(microseconds: (v as num).toInt())),
+          androidStaleAfter: $checkedConvert(
+              'androidStaleAfter',
+              (v) => v == null
+                  ? _defaultStaleAfter
+                  : AlarmSettings._staleAfterFromJson(v)),
         );
         return val;
       },
@@ -67,4 +72,6 @@ Map<String, dynamic> _$AlarmSettingsToJson(AlarmSettings instance) =>
       if (instance.payload case final value?) 'payload': value,
       if (instance.androidSnoozeDuration?.inMicroseconds case final value?)
         'androidSnoozeDuration': value,
+      'androidStaleAfter':
+          AlarmSettings._staleAfterToJson(instance.androidStaleAfter),
     };

--- a/lib/src/generated/platform_bindings.g.dart
+++ b/lib/src/generated/platform_bindings.g.dart
@@ -110,6 +110,7 @@ class AlarmSettingsWire {
     required this.androidStopAlarmOnTermination,
     required this.preferConnectedAudioDevice,
     this.androidSnoozeDurationMillis,
+    this.androidStaleAfterMillis,
   });
 
   int id;
@@ -148,6 +149,14 @@ class AlarmSettingsWire {
   /// cancellation. Android only.
   int? androidSnoozeDurationMillis;
 
+  /// How long past its due time an alarm found at boot is still worth
+  /// ringing, in milliseconds.
+  ///
+  /// Null means never discard. Absent from an alarm stored before the
+  /// setting existed, which reads as the default rather than as null.
+  /// Android only.
+  int? androidStaleAfterMillis;
+
   List<Object?> _toList() {
     return <Object?>[
       id,
@@ -165,6 +174,7 @@ class AlarmSettingsWire {
       androidStopAlarmOnTermination,
       preferConnectedAudioDevice,
       androidSnoozeDurationMillis,
+      androidStaleAfterMillis,
     ];
   }
 
@@ -190,6 +200,7 @@ class AlarmSettingsWire {
       androidStopAlarmOnTermination: result[12]! as bool,
       preferConnectedAudioDevice: result[13]! as bool,
       androidSnoozeDurationMillis: result[14] as int?,
+      androidStaleAfterMillis: result[15] as int?,
     );
   }
 

--- a/pigeons/alarm_api.dart
+++ b/pigeons/alarm_api.dart
@@ -32,6 +32,7 @@ class AlarmSettingsWire {
     required this.androidStopAlarmOnTermination,
     required this.preferConnectedAudioDevice,
     required this.androidSnoozeDurationMillis,
+    required this.androidStaleAfterMillis,
   });
 
   final int id;
@@ -56,6 +57,14 @@ class AlarmSettingsWire {
   /// below a few seconds, which survives neither process death nor
   /// cancellation. Android only.
   final int? androidSnoozeDurationMillis;
+
+  /// How long past its due time an alarm found at boot is still worth
+  /// ringing, in milliseconds.
+  ///
+  /// Null means never discard. Absent from an alarm stored before the
+  /// setting existed, which reads as the default rather than as null.
+  /// Android only.
+  final int? androidStaleAfterMillis;
 }
 
 class VolumeSettingsWire {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: alarm
 description: A simple Flutter alarm manager plugin for both iOS and Android.
-version: 5.10.0
+version: 5.11.0
 homepage: https://github.com/gdelataillade/alarm
 
 environment:

--- a/test/alarm_settings_test.dart
+++ b/test/alarm_settings_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:alarm/alarm.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -251,6 +253,113 @@ void main() {
 
     test('different ids compare unequal', () {
       expect(buildSettings(), isNot(equals(buildSettings(id: 2))));
+    });
+  });
+
+  group('AlarmSettings androidStaleAfter', () {
+    // Three states have to survive storage, and a plain nullable field cannot
+    // express them: json_serializable omits a null from the encoded map, and
+    // reads a missing key as the constructor default. That would turn "never
+    // discard" into fifteen minutes on the first restart after it was set,
+    // which is the one moment the choice matters.
+    Map<String, dynamic> encoded(AlarmSettings settings) =>
+        jsonDecode(jsonEncode(settings.toJson())) as Map<String, dynamic>;
+
+    test('defaults to fifteen minutes when the caller says nothing', () {
+      expect(AlarmSettings.defaultStaleAfter, const Duration(minutes: 15));
+      expect(
+        buildSettings().androidStaleAfter,
+        AlarmSettings.defaultStaleAfter,
+      );
+    });
+
+    test('an explicit null survives a round trip as never discard', () {
+      final json =
+          encoded(buildSettings().copyWith(androidStaleAfter: () => null));
+
+      expect(json['androidStaleAfter'], AlarmSettings.neverDiscardSentinel);
+      expect(AlarmSettings.fromJson(json).androidStaleAfter, isNull);
+    });
+
+    test('a duration survives a round trip', () {
+      final json = encoded(
+        buildSettings().copyWith(
+          androidStaleAfter: () => const Duration(minutes: 40),
+        ),
+      );
+
+      expect(
+        AlarmSettings.fromJson(json).androidStaleAfter,
+        const Duration(minutes: 40),
+      );
+    });
+
+    test('an alarm stored before the setting existed takes the default', () {
+      final json = encoded(buildSettings())..remove('androidStaleAfter');
+
+      expect(
+        AlarmSettings.fromJson(json).androidStaleAfter,
+        AlarmSettings.defaultStaleAfter,
+      );
+    });
+
+    test('an integral double is read as that duration', () {
+      final json = buildSettings().toJson()
+        ..['androidStaleAfter'] =
+            const Duration(minutes: 20).inMicroseconds * 1.0;
+
+      expect(
+        AlarmSettings.fromJson(json).androidStaleAfter,
+        const Duration(minutes: 20),
+      );
+    });
+
+    test('an unusable value falls back to the default rather than throwing',
+        () {
+      // Throwing would be worse than wrong: nothing between Alarm.init and the
+      // storage read catches, so one malformed field would cost the user every
+      // stored alarm. A fraction is in the list because 1.5 microseconds would
+      // otherwise truncate to a one-microsecond window and discard everything.
+      for (final unusable in <Object?>[
+        'oops',
+        1.5,
+        -2,
+        double.nan,
+        double.infinity,
+        <int>[],
+        <String, int>{},
+      ]) {
+        final json = buildSettings().toJson()..['androidStaleAfter'] = unusable;
+
+        expect(
+          AlarmSettings.fromJson(json).androidStaleAfter,
+          AlarmSettings.defaultStaleAfter,
+          reason: 'for $unusable',
+        );
+      }
+    });
+
+    test('toWire sends milliseconds, and null for never discard', () {
+      expect(buildSettings().toWire().androidStaleAfterMillis, 900000);
+      expect(
+        buildSettings()
+            .copyWith(androidStaleAfter: () => null)
+            .toWire()
+            .androidStaleAfterMillis,
+        isNull,
+      );
+    });
+
+    test('copyWith can clear it and set it back', () {
+      final never = buildSettings().copyWith(androidStaleAfter: () => null);
+      expect(never.androidStaleAfter, isNull);
+
+      final restored =
+          never.copyWith(androidStaleAfter: () => const Duration(hours: 1));
+      expect(restored.androidStaleAfter, const Duration(hours: 1));
+
+      // Not passing it at all leaves the choice alone, including the null one.
+      expect(never.copyWith(id: 9).androidStaleAfter, isNull);
     });
   });
 }

--- a/test/alarm_validation_test.dart
+++ b/test/alarm_validation_test.dart
@@ -77,6 +77,49 @@ void main() {
       );
     });
 
+    test('rejects an androidStaleAfter below the ring-start grace', () {
+      // Below the grace checkAlarm gives a due alarm, Dart would leave alone an
+      // alarm the boot path had already discarded, so the two stores would
+      // disagree about whether it still exists. Caught at set() rather than
+      // silently at the next boot.
+      expect(
+        () => Alarm.alarmSettingsValidation(
+          buildSettings(42).copyWith(
+            androidStaleAfter: () => const Duration(seconds: 29),
+          ),
+        ),
+        throwsA(
+          isA<AlarmException>().having(
+            (e) => e.code,
+            'code',
+            AlarmErrorCode.invalidArguments,
+          ),
+        ),
+      );
+    });
+
+    test('accepts an androidStaleAfter at the grace, and never discarding', () {
+      expect(
+        () => Alarm.alarmSettingsValidation(
+          buildSettings(42).copyWith(
+            androidStaleAfter: () => const Duration(seconds: 30),
+          ),
+        ),
+        returnsNormally,
+      );
+      expect(
+        () => Alarm.alarmSettingsValidation(
+          buildSettings(42).copyWith(androidStaleAfter: () => null),
+        ),
+        returnsNormally,
+      );
+      // And the default an ordinary caller gets.
+      expect(
+        () => Alarm.alarmSettingsValidation(buildSettings(42)),
+        returnsNormally,
+      );
+    });
+
     test('rejects a non-positive snooze duration', () {
       expect(
         () => Alarm.alarmSettingsValidation(


### PR DESCRIPTION
Closes #418. Built to the specification in your last comment there, with the serialization change from the comment above this one.

### What changed

`BootReceiver` re-armed every stored alarm with no age limit. It now discards one missed by more than `AlarmSettings.androidStaleAfter` and records a `DROPPED` marker with cause `STALE_AT_BOOT`. Nothing is reported from there — no engine is running at boot — so Dart drains it on the next `init()` and it surfaces through `Alarm.events`. The plugin still shows the user nothing itself.

`AlarmSettings.androidStaleAfter` defaults to 15 minutes; an explicit `null` never discards.

### The one place I departed from the spec

`Duration?` with a 15-minute default is unchanged, but it needed help to persist. `json_serializable` omits a null field from the encoded map and reads a missing key as the constructor default, so "never discard" became 15 minutes on the first launch after it was set. `androidStaleAfter` is written as a `-1` sentinel instead of JSON null, which keeps absent and null apart without touching the public shape. Since `toJson()` is public, the sentinel is documented on the field as part of its contract.

An unusable value — a string, a fraction, a non-finite number, any other negative — recovers to the default with a warning rather than throwing. Nothing between `Alarm.init` and the storage read catches, so a throw would cost the user every stored alarm over one malformed field, which is a worse failure than the one it would be guarding against. The Kotlin side keeps the same three states apart: kotlinx already separates absent from null, and the lenient parser checks key presence rather than relying on `primitiveLong`, which returns null for both.

`primitiveLong` staying as it is, by the way, is deliberate — the collapse only matters for a key that can legitimately be null, and changing the helper would touch every field that uses it.

### Why `AlarmStorage` is in this diff

Marker expiry aged from `atMillis`, the moment the event describes. That is right for a `MOVED`, where it is the time the alarm now rings. A `STALE_AT_BOOT` discard describes a due time that had already passed — days ago, since that is exactly what made the alarm stale — so the marker was written already older than the 24 h discard TTL and `getPendingAlarmEvents` deleted it on the first read. The device was off for a day, every stale alarm was discarded correctly, and the application heard about none of them.

It is invisible today because the only existing `DROPPED` is a refused ring, recorded within seconds of the time it describes, so there the two timestamps are interchangeable.

Expiry now ages from `maxOf(atMillis, recordedAtMillis)`. Deferrals are unaffected, since the ring time is the later value, and the change can only extend a marker's life — never shorten it — so nothing that survives today starts expiring.

### Validation

`alarmSettingsValidation` throws `invalidArguments` below the 30 s ring-start grace, at `set()` rather than silently at the next boot.

### Tests

99 Dart, 32 Kotlin (15 new), all passing; analyze and format clean.

Both sides cover the three states — absent takes the default, `-1`/explicit null never discards, a value is itself — plus the recovery path, the boundary (exactly 15 minutes still rings), a longer per-alarm window, and that discarding leaves the alarm gone with a marker naming the cause and the time it should have rung. On expiry: an alarm missed by three days still reaches Dart end to end, a discard recorded now survives a long-past due time, and a discard recorded two days ago is still pruned so the TTL keeps biting.

Revert-proved, each against the change it covers: removing the `@JsonKey` converters fails the round-trip and recovery tests, making `isStale` always return false fails two boot tests, and restoring the old expiry expression fails two of the three above.

**Not covered:** the wiring inside `rescheduleAlarms` that calls them. `BootReceiver` needs a `Context`, and the Kotlin test source set is plain JUnit with no Robolectric, so `isStale` and `discardStaleAlarm` moved to the companion object and are tested directly. The three lines that call them in the loop are not.

### Two things for you

The version bump assumes this lands before #431 — both claim 5.11.0, so whichever is second needs a rebase to 5.12.0. I merged the two locally to see what that costs: only the CHANGELOG conflicts, `lib/alarm.dart` merges cleanly despite both branches working in it, and the combined tree is green — 113 Dart and 32 Kotlin, analyze clean. Happy to do the rebase on this one whichever order you pick.

The `init()`/boot asymmetry you asked me to leave alone is untouched. `_checkAlarm` still stops an equally stale alarm silently.
