### PR TITLE
feat: deprecate Alarm.snoozed in favour of Alarm.events (#435)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.12.0
+* **Deprecated `Alarm.snoozed` (#435).** Listen to `Alarm.events` and filter on `AlarmEventCause.snooze` instead: it reports the same deferrals and also carries `recordedAt`, which `Alarm.acknowledgeEvent()` needs. A subscriber to `Alarm.snoozed` is handed only `(id, nextRingAt)`, so under `Alarm.init(acknowledgeEventsAutomatically: false)` it has nothing to acknowledge with and the marker is redelivered on every `init()` until it expires a week later. No removal version, matching `updateStream` and `ringStream`.
+
 ## 5.11.0
 * **[Android] An alarm whose time passed while the device was off is now discarded instead of ringing at boot (#418).** Reported on `Alarm.events` as an `AlarmDropped` with cause `staleAtBoot`.
 * Added `AlarmSettings.androidStaleAfter`, the cutoff for that: 15 minutes by default, `null` never discards.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 5.12.0
-* **Deprecated `Alarm.snoozed` (#435).** Listen to `Alarm.events` and filter on `AlarmEventCause.snooze` instead: it reports the same deferrals and also carries `recordedAt`, which `Alarm.acknowledgeEvent()` needs. A subscriber to `Alarm.snoozed` is handed only `(id, nextRingAt)`, so under `Alarm.init(acknowledgeEventsAutomatically: false)` it has nothing to acknowledge with and the marker is redelivered on every `init()` until it expires a week later. No removal version, matching `updateStream` and `ringStream`.
+* **Deprecated `Alarm.snoozed` (#435).** Listen to `Alarm.events` and filter on `AlarmEventCause.snooze` instead: same deferrals, plus the `recordedAt` that `Alarm.acknowledgeEvent()` needs. No removal version.
 
 ## 5.11.0
 * **[Android] An alarm whose time passed while the device was off is now discarded instead of ringing at boot (#418).** Reported on `Alarm.events` as an `AlarmDropped` with cause `staleAtBoot`.

--- a/README.md
+++ b/README.md
@@ -219,9 +219,10 @@ Two things to know before you do:
 - **An event you never acknowledge is redelivered on every `init()`** until the native marker
   expires — 24 h for an `AlarmDropped`, a week for an `AlarmMoved`. Acknowledge every event you are
   given, including ones you decide to ignore.
-- **The setting is per-isolate**, and `Alarm.snoozed` carries no handle to acknowledge with. Pass it
-  in every isolate that calls `init()`, and use `Alarm.events` rather than `Alarm.snoozed` if you
-  take the boundary.
+- **The setting is per-isolate.** Pass it in every isolate that calls `init()`.
+- **The deprecated `Alarm.snoozed` cannot take part.** It carries no `recordedAt`, so a subscriber
+  there has nothing to acknowledge with and the marker is redelivered on every launch until it
+  expires a week later. Filter `Alarm.events` on `AlarmEventCause.snooze` instead.
 
 ## 📱 Example app
 
@@ -427,14 +428,23 @@ Below that, Android stops scheduling through `AlarmManager` and falls back to
 an in-process timer that survives neither app termination nor cancellation, so
 a shorter snooze could be neither guaranteed nor undone.
 
-A snooze is reported as `Alarm.snoozed`, never as a stop, because the alarm is
+A snooze is reported on `Alarm.events`, never as a stop, because the alarm is
 still owed:
 
 ```Dart
-Alarm.snoozed.listen((snooze) {
+Alarm.events
+    .where((e) => e is AlarmMoved && e.cause == AlarmEventCause.snooze)
+    .cast<AlarmMoved>()
+    .listen((snooze) {
   print('Alarm ${snooze.id} rings again at ${snooze.nextRingAt}');
 });
 ```
+
+> `Alarm.snoozed` reports the same deferrals in a shorter form and still works,
+> but it is **deprecated**: it hands you `(id, nextRingAt)` with no
+> `recordedAt`, so a subscriber there has nothing to pass to
+> `Alarm.acknowledgeEvent`. See
+> [taking the durability boundary yourself](#taking-the-durability-boundary-yourself).
 
 The alarm also leaves `Alarm.ringing` and reappears in `Alarm.scheduled` with
 its new `dateTime`, so an app that tracks alarm state through those streams
@@ -448,7 +458,7 @@ record is kept until Dart confirms it stored the new time, so a crash in
 between loses nothing, and applying the same deferral twice does nothing the
 second time.
 
-`Alarm.snoozed` is buffered, so subscribing after `Alarm.init()` — the order the
+`Alarm.events` is buffered, so subscribing after `Alarm.init()` — the order the
 setup above recommends — still delivers a deferral replayed during it. A
 listener that subscribes later receives it too, so key any irreversible reaction
 on the alarm id and the deferral time rather than assuming one delivery.

--- a/example/lib/screens/home.dart
+++ b/example/lib/screens/home.dart
@@ -11,7 +11,7 @@ import 'package:alarm_example/widgets/tile.dart';
 import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-const version = '5.11.0';
+const version = '5.12.0';
 
 class ExampleAlarmHomeScreen extends StatefulWidget {
   const ExampleAlarmHomeScreen({super.key});
@@ -26,7 +26,7 @@ class _ExampleAlarmHomeScreenState extends State<ExampleAlarmHomeScreen> {
 
   StreamSubscription<AlarmSet>? ringSubscription;
   StreamSubscription<AlarmSet>? updateSubscription;
-  StreamSubscription<({int id, DateTime nextRingAt})>? snoozeSubscription;
+  StreamSubscription<AlarmMoved>? snoozeSubscription;
 
   @override
   void initState() {
@@ -42,11 +42,19 @@ class _ExampleAlarmHomeScreenState extends State<ExampleAlarmHomeScreen> {
     // Android only. Receives snoozes taken while the app is running, and also
     // the ones replayed during Alarm.init() -- the stream is buffered, so
     // subscribing from a widget built after init still delivers those.
-    snoozeSubscription = Alarm.snoozed.listen(snoozed);
+    // Alarm.events rather than the deprecated Alarm.snoozed: the same
+    // deferrals, plus the recordedAt that Alarm.acknowledgeEvent needs.
+    snoozeSubscription = Alarm.events
+        .where(
+          (event) =>
+              event is AlarmMoved && event.cause == AlarmEventCause.snooze,
+        )
+        .cast<AlarmMoved>()
+        .listen(snoozed);
     notifications = Notifications();
   }
 
-  void snoozed(({int id, DateTime nextRingAt}) snooze) {
+  void snoozed(AlarmMoved snooze) {
     if (!mounted) return;
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "5.11.0"
+    version: "5.12.0"
   args:
     dependency: transitive
     description:

--- a/lib/alarm.dart
+++ b/lib/alarm.dart
@@ -119,22 +119,28 @@ class Alarm {
   /// Stream of alarms deferred on the host side, with the instant each one
   /// rings again.
   ///
+  /// **Deprecated. Listen to [events] and filter on [AlarmEventCause.snooze]
+  /// instead**, which reports the same deferrals and carries one more field.
+  ///
+  /// That field is the one a manual acknowledgement boundary needs. A
+  /// subscriber here is handed `(id, nextRingAt)`, while [acknowledgeEvent]
+  /// needs the event's `recordedAt`, so there is nothing to acknowledge with.
+  /// Under `Alarm.init(acknowledgeEventsAutomatically: false)` the host keeps
+  /// an unacknowledged snooze marker for a week and re-emits it on every
+  /// [init], so a listener that shows the user a snackbar would show it again
+  /// on every launch until then, and no care taken in the application can
+  /// prevent it. That dead end is also why automatic acknowledgement stayed
+  /// the default rather than becoming a staged migration; see [events].
+  ///
+  /// Everything below still holds while it remains.
+  ///
   /// A snooze never reaches [ringing] as a stop: the alarm is still owed, and
   /// an application tracking its own alarm state needs to record a deferral
   /// rather than a dismissal.
   ///
   /// Only covers user snoozes. [events] reports every change the host makes to
   /// an alarm on its own, including deferrals the platform forced and alarms
-  /// discarded as stale, and is the stream to prefer for new code.
-  ///
-  /// Not a stream a manual acknowledgement boundary can be built on. A
-  /// subscriber here is handed `(id, nextRingAt)`, while [acknowledgeEvent]
-  /// needs the event's `recordedAt`, so there is nothing to acknowledge with.
-  /// Under `Alarm.init(acknowledgeEventsAutomatically: false)` the host keeps
-  /// an unacknowledged snooze marker for a week and re-emits it on every
-  /// [init], so a listener that shows the user a snackbar would show it again
-  /// on every launch until then. An application that takes the boundary should
-  /// listen to [events] and filter on [AlarmEventCause.snooze] itself.
+  /// discarded as stale.
   ///
   /// A view over [events] rather than a stream of its own, so the two can never
   /// disagree about a deferral, and so this inherits the buffering described
@@ -142,6 +148,7 @@ class Alarm {
   /// it. Before that it was a plain broadcast stream, and a deferral taken with
   /// no engine running reached only listeners that already existed — which the
   /// documented `await Alarm.init()` in `main` made unlikely.
+  @Deprecated('Use [events] and filter on [AlarmEventCause.snooze].')
   static Stream<({int id, DateTime nextRingAt})> get snoozed => _events.stream
       .where(
         (event) => event is AlarmMoved && event.cause == AlarmEventCause.snooze,
@@ -195,7 +202,9 @@ class Alarm {
   /// hands its subscriber `(id, nextRingAt)`, and [acknowledgeEvent] needs the
   /// event's `recordedAt`. Making the manual path mandatory would leave that
   /// stream replaying every deferral on each launch with nothing able to
-  /// acknowledge it. Consume this stream instead if you want the boundary.
+  /// acknowledge it. Consume this stream instead if you want the boundary —
+  /// [snoozed] is deprecated for that reason, which is the other half of the
+  /// same decision.
   ///
   /// The plugin deliberately shows the user nothing for these. An
   /// [AlarmDropped] in particular is worth surfacing, but only the application

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: alarm
 description: A simple Flutter alarm manager plugin for both iOS and Android.
-version: 5.11.0
+version: 5.12.0
 homepage: https://github.com/gdelataillade/alarm
 
 environment:

--- a/test/alarm_event_test.dart
+++ b/test/alarm_event_test.dart
@@ -98,6 +98,9 @@ void main() {
       host.pending.add(droppedEvent(42, scheduledFor));
 
       final snoozes = <({int id, DateTime nextRingAt})>[];
+      // Deprecated in favour of Alarm.events, but still shipped, so what it
+      // must NOT report is still worth asserting.
+      // ignore: deprecated_member_use_from_same_package
       final subscription = Alarm.snoozed.listen(snoozes.add);
       addTearDown(subscription.cancel);
 
@@ -233,6 +236,9 @@ void main() {
       final seen = <AlarmEvent>[];
       final snoozes = <({int id, DateTime nextRingAt})>[];
       final events = Alarm.events.listen(seen.add);
+      // Deprecated in favour of Alarm.events, but still shipped, so what it
+      // must NOT report is still worth asserting.
+      // ignore: deprecated_member_use_from_same_package
       final snoozed = Alarm.snoozed.listen(snoozes.add);
       addTearDown(events.cancel);
       addTearDown(snoozed.cancel);

--- a/test/alarm_snooze_test.dart
+++ b/test/alarm_snooze_test.dart
@@ -121,6 +121,9 @@ void main() {
       await Alarm.init();
 
       final seen = <({int id, DateTime nextRingAt})>[];
+      // Deprecated in favour of Alarm.events, but still shipped, and this
+      // group is the coverage that keeps it behaving as documented.
+      // ignore: deprecated_member_use_from_same_package
       final subscription = Alarm.snoozed.listen(seen.add);
       addTearDown(subscription.cancel);
       await pump();
@@ -200,6 +203,87 @@ void main() {
     });
   });
 
+  group('the documented replacement for Alarm.snoozed', () {
+    // README and the example app now tell applications to filter Alarm.events
+    // themselves rather than use the deprecated view. If the two ever stopped
+    // agreeing, that advice would silently start losing deferrals, so pin the
+    // equivalence rather than trusting the getter's one-line body.
+    test('sees every deferral the deprecated stream sees, plus recordedAt',
+        () async {
+      final nextRingAt = DateTime.now().add(const Duration(minutes: 9));
+      // Deliberately not nextRingAt: a marker drained on a later init was
+      // recorded when the user pressed Snooze, and the whole point of the
+      // field is that it answers a different question from "when does it ring".
+      final recordedAt = DateTime.now().subtract(const Duration(minutes: 3));
+      await AlarmStorage.saveAlarm(
+        buildAlarm(23, DateTime.now().add(const Duration(minutes: 1))),
+      );
+      await Alarm.init();
+
+      final viaEvents = <AlarmMoved>[];
+      final subEvents = Alarm.events
+          .where(
+            (event) =>
+                event is AlarmMoved && event.cause == AlarmEventCause.snooze,
+          )
+          .cast<AlarmMoved>()
+          .listen(viaEvents.add);
+      final viaSnoozed = <({int id, DateTime nextRingAt})>[];
+      // Deprecated in favour of Alarm.events, but still shipped, and this
+      // group is the coverage that keeps it behaving as documented.
+      // ignore: deprecated_member_use_from_same_package
+      final subSnoozed = Alarm.snoozed.listen(viaSnoozed.add);
+      addTearDown(subEvents.cancel);
+      addTearDown(subSnoozed.cancel);
+
+      await hostReportsEvent(
+        snoozeEvent(23, nextRingAt, recordedAt: recordedAt),
+      );
+      await pump();
+
+      expect(viaSnoozed, hasLength(1));
+      expect(
+        viaEvents.map((event) => (id: event.id, nextRingAt: event.nextRingAt)),
+        viaSnoozed,
+        reason: 'the filter the docs prescribe must yield the same deferrals',
+      );
+      expect(
+        viaEvents.single.recordedAt.millisecondsSinceEpoch,
+        recordedAt.millisecondsSinceEpoch,
+        reason: 'the field Alarm.snoozed drops, and the reason to move; '
+            'acknowledgeEvent is keyed on it',
+      );
+    });
+
+    test('a deferral the platform forced reaches only the replacement',
+        () async {
+      // The deprecated stream deliberately means "the user snoozed". Anyone
+      // migrating to the raw filter keeps that distinction only because the
+      // cause is part of it.
+      final nextRingAt = DateTime.now().add(const Duration(seconds: 30));
+      await AlarmStorage.saveAlarm(
+        buildAlarm(24, DateTime.now().subtract(const Duration(seconds: 5))),
+      );
+      await Alarm.init();
+
+      final viaEvents = <AlarmEvent>[];
+      final subEvents = Alarm.events.listen(viaEvents.add);
+      final viaSnoozed = <({int id, DateTime nextRingAt})>[];
+      // Deprecated in favour of Alarm.events, but still shipped, and this
+      // group is the coverage that keeps it behaving as documented.
+      // ignore: deprecated_member_use_from_same_package
+      final subSnoozed = Alarm.snoozed.listen(viaSnoozed.add);
+      addTearDown(subEvents.cancel);
+      addTearDown(subSnoozed.cancel);
+
+      await hostReportsEvent(refusedRingEvent(24, nextRingAt));
+      await pump();
+
+      expect(viaSnoozed, isEmpty, reason: 'the user did not snooze this');
+      expect(viaEvents.single.cause, AlarmEventCause.platformRefusal);
+    });
+  });
+
   group('live snooze report', () {
     test('moves the alarm forward and emits on Alarm.snoozed', () async {
       final nextRingAt = DateTime.now().add(const Duration(minutes: 9));
@@ -209,6 +293,9 @@ void main() {
       await Alarm.init();
 
       final events = <({int id, DateTime nextRingAt})>[];
+      // Deprecated in favour of Alarm.events, but still shipped, and this
+      // group is the coverage that keeps it behaving as documented.
+      // ignore: deprecated_member_use_from_same_package
       final sub = Alarm.snoozed.listen(events.add);
       addTearDown(sub.cancel);
 
@@ -232,6 +319,9 @@ void main() {
       await Alarm.init();
 
       final events = <({int id, DateTime nextRingAt})>[];
+      // Deprecated in favour of Alarm.events, but still shipped, and this
+      // group is the coverage that keeps it behaving as documented.
+      // ignore: deprecated_member_use_from_same_package
       final sub = Alarm.snoozed.listen(events.add);
       addTearDown(sub.cancel);
 


### PR DESCRIPTION
Closes #435.

`Alarm.snoozed` gets `@Deprecated('Use [events] and filter on [AlarmEventCause.snooze].')`, with no removal version, matching `updateStream` and `ringStream` in the same file. Everything in the issue's "what to do", nothing from its "alternative".

### The dartdoc

Reordered rather than appended to. It already carried the whole argument — `(id, nextRingAt)` against the `recordedAt` that `acknowledgeEvent` needs — but reached it in the fourth paragraph, which is the wrong shape for a deprecated member. It now leads with the deprecation and the replacement, then keeps what still holds under a line saying so.

The `events` dartdoc explains that automatic acknowledgement stayed the default *because* `snoozed` cannot take part in the manual boundary. That paragraph now records that the deprecation is the other half of the same decision, so the two sites don't drift.

### Example and README

The example app was demonstrating exactly the failure the issue describes — a snooze snackbar that a manual-boundary app could never acknowledge, redelivered on every launch for a week. Migrated to `Alarm.events`, which also means the example no longer teaches the deprecated call.

README's snooze snippet does the same, with a note that `Alarm.snoozed` still works. I deliberately kept a version number out of that prose so it cannot go stale; the two acknowledgement caveats are now split, since "per-isolate" and "`snoozed` has no handle" were one bullet making two unrelated points.

### Two new tests

The README and the example now tell applications to write the filter themselves. If `snoozed` and that filter ever stopped agreeing, that advice would quietly start losing deferrals — so the equivalence is pinned rather than left to a one-line getter body:

- the prescribed filter yields the same deferrals, plus the `recordedAt` that `snoozed` drops (asserted against a `recordedAt` deliberately different from `nextRingAt`, since the field only earns its place by answering a different question);
- a deferral the platform forced reaches only the replacement.

Both were checked against a mutated getter rather than assumed to bite: inverting the cause test fails the first, and mapping `recordedAt` in place of `nextRingAt` fails the equivalence assertion specifically. The three existing tests that cover `snoozed` itself keep covering it while it ships, with the ignore documented at each site.

### Verified

`flutter analyze` clean, 115 tests pass, example Android debug build passes, formatter clean, `dart pub publish --dry-run` clean. The README snippet was compile-checked against the real API, and the deprecation was confirmed to fire on a consumer with the intended message rather than assumed from the annotation.

### One thing for you

I versioned this `5.12.0` in `pubspec.yaml`, `CHANGELOG.md`, `example/pubspec.lock` and the example's displayed `version` const. That is a guess — you renumbered my last one — so all four move together if you'd rather it were something else. `example/pubspec.lock` is the version line only; `pub get` keeps trying to drag unrelated transitive downgrades in with it and those are stripped.
